### PR TITLE
Use window.crypto.getRandomValues() as a seed if available

### DIFF
--- a/js/random.js
+++ b/js/random.js
@@ -85,6 +85,24 @@ if(typeof(navigator) !== 'undefined') {
   _navBytes = null;
 }
 
+// window.crypto.getRandomValues is a strong source of randomness if available
+if (window && window.crypto && window.crypto.getRandomValues) {
+  // completely fill the generator: 32 pools, each of which wants 32 bytes of data
+  // TODO: is this a good target?
+  var ENTROPY_BYTES = 32*32;
+  var entropy = new Uint32Array(ENTROPY_BYTES/4);
+  try {
+    window.crypto.getRandomValues(entropy);
+    for (var i = 0; i < entropy.length; i++) {
+      _ctx.collectInt(entropy[i], 32);
+    }
+  } catch (e) {
+    // Mozilla claims getRandomValues can throw QuotaExceededError, so ignore errors
+    // https://developer.mozilla.org/en-US/docs/DOM/window.crypto.getRandomValues
+    // However I've never observed this exception
+  }
+}
+
 // add mouse and keyboard collectors if jquery is available
 if($) {
   // set up mouse entropy capture


### PR DESCRIPTION
Comments welcomed, particularly about how many bytes I should be reading (I'm assuming I should fill the first pool?), and if it should even bother with any of the other entropy sources if this one exists (this is supposed to be "strong").

Tested with Chrome (supported), Safari (supported), Firefox 20 (not supported) and Firefox 21 (supported).

Fixes #10
