### PR TITLE
Add forge.random.seed() to seed the internal PRNG

### DIFF
--- a/js/random.js
+++ b/js/random.js
@@ -144,6 +144,20 @@ forge.random.registerWorker = function(worker) {
   _ctx.registerWorker(worker);
 };
 
+/**
+ * Adds bytes of entropy to forge.random's PRNG.
+ */
+forge.random.collect = function(bytes) {
+  return _ctx.collect(bytes);
+};
+
+/**
+ * Adds n bits of entropy from integer i to forge.random's PRNG.
+ */
+forge.random.collectInt = function(i, n) {
+  return _ctx.collectInt(i, n);
+};
+
 })(typeof(jQuery) !== 'undefined' ? jQuery : null);
 
 } // end module implementation


### PR DESCRIPTION
Web workers don't have access to window.crypto.getRandomValues, so this
allows callers to pass "strong" entropy into the forge.random generator.

This may not be the "right" implementation, but I need some way to get data into that PRNG, since that is what gets used for RSA key generation (with no easy way to override it, beyond fiddling with the "internals" of the object.
