### PR TITLE
remove a couple of trailing commas in lists

### DIFF
--- a/js/pki.js
+++ b/js/pki.js
@@ -2823,7 +2823,7 @@ pki.encryptPrivateKeyInfo = function(obj, password, options) {
             // iteration count
             asn1.create(asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,
               countBytes.getBytes())
-          ]),
+          ])
         ]),
         // encryptionScheme
         asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
@@ -2831,7 +2831,7 @@ pki.encryptPrivateKeyInfo = function(obj, password, options) {
             asn1.oidToDer(encOid).getBytes()),
           // iv
           asn1.create(
-            asn1.Class.UNIVERSAL, asn1.Type.OCTETSTRING, false, iv),
+            asn1.Class.UNIVERSAL, asn1.Type.OCTETSTRING, false, iv)
         ])
       ])
     ]);


### PR DESCRIPTION
FYI, the TLS test is broken in python2.7 due to this bug: https://bugs.launchpad.net/pyopenssl/+bug/755852
...rd things.
