### PR TITLE
Better test to see if we're running in Node.JS without breaking CommonJS browser apps

### DIFF
--- a/js/prng.js
+++ b/js/prng.js
@@ -11,7 +11,7 @@
 /* ########## Begin module implementation ########## */
 function initModule(forge) {
 
-var _nodejs = (typeof module === 'object' && module.exports);
+var _nodejs = (typeof process !== 'undefined' && process.versions && process.versions.node);
 var crypto = null;
 if(_nodejs) {
   crypto = require('crypto');

--- a/js/random.js
+++ b/js/random.js
@@ -70,7 +70,7 @@ var _ctx = forge.prng.create(prng_aes);
 
 // add other sources of entropy only if window.crypto.getRandomValues is not
 // available -- otherwise this source will be automatically used by the prng
-var _nodejs = (typeof module === 'object' && module.exports);
+var _nodejs = (typeof process !== 'undefined' && process.versions && process.versions.node);
 if(!_nodejs && !(typeof window !== 'undefined' &&
   window.crypto && window.crypto.getRandomValues)) {
 

--- a/js/rsa.js
+++ b/js/rsa.js
@@ -9,8 +9,6 @@
 function initModule(forge) {
 /* ########## Begin module implementation ########## */
 
-var _nodejs = (typeof module === 'object' && module.exports);
-
 if(typeof BigInteger === 'undefined') {
   BigInteger = forge.jsbn.BigInteger;
 }


### PR DESCRIPTION
A better check for Node.JS which takes into account the fact that some browser deployments may use CommonJS rather than AMD.
