### PR TITLE
fix DER encoding of BIT STRING values

### DIFF
--- a/js/asn1.js
+++ b/js/asn1.js
@@ -428,6 +428,12 @@ asn1.toDer = function(obj) {
         value.putInt16(obj.value.charCodeAt(i));
       }
     }
+    else if(obj.type === asn1.Type.BITSTRING) {
+      // BER say that the first content byte should be the number of unused bits.
+      // we just put in 0x00 here
+      value.putByte(0x00);
+      value.putBytes(obj.value);
+    }
     else {
       value.putBytes(obj.value);
     }

--- a/nodejs/test/asn1.js
+++ b/nodejs/test/asn1.js
@@ -100,6 +100,16 @@ function Tests(ASSERT, ASN1, UTIL) {
         });
       }
     })();
+
+
+    it("should correctly DER encode and decode BIT STRING type", function() {
+      var bs = UTIL.hexToBytes("01020304ff");
+      var value = ASN1.create(ASN1.Class.UNIVERSAL, ASN1.Type.BITSTRING, false, bs);
+
+      var expectedHex = "03060001020304ff";
+      var derHex = UTIL.bytesToHex(ASN1.toDer(value).bytes());
+      ASSERT.equal(derHex, expectedHex);
+    });
   });
 }
 


### PR DESCRIPTION
Quote (http://luca.ntop.org/Teaching/Appunti/asn1.html):

>  In a primitive encoding, the first contents octet gives the number of bits by which the length of the bit string is less than the next multiple of eight (this is called the "number of unused bits")

This was not followed, leaving wrongly encoded DER (which caused me some headache to debug  till I found this :-) ) 

This PR fixes this (BTW tests are failing for current master?)
