### PR TITLE
fixed getRandomValues for IE10

### DIFF
--- a/js/prng.js
+++ b/js/prng.js
@@ -249,7 +249,7 @@ prng.create = function(plugin) {
     var getRandomValues = null;
     if(typeof window !== 'undefined') {
       var crypto = window.crypto || window.msCrypto;
-      if(crypto.getRandomValues) {
+      if(crypto && crypto.getRandomValues) {
         getRandomValues = function(arr) {
           return crypto.getRandomValues(arr);
         };


### PR DESCRIPTION
In IE10 var crypto is undefined after line 251: var crypto = window.crypto || window.msCrypto;
So line 252 will crash with "cannot read getRandomValues of undefined"
