### PR TITLE
Math.random() corner case

### DIFF
--- a/js/prng.js
+++ b/js/prng.js
@@ -285,7 +285,7 @@ prng.create = function(plugin) {
       implemented with David G. Carta's optimization: with 32 bit math
       and without division (Public Domain). */
       var hi, lo, next;
-      var seed = Math.floor(Math.random() * 0xFFFF);
+      var seed = Math.floor(Math.random() * 0x010000);
       while(b.length() < needed) {
         lo = 16807 * (seed & 0xFFFF);
         hi = 16807 * (seed >> 16);
@@ -298,7 +298,7 @@ prng.create = function(plugin) {
         for(var i = 0; i < 3; ++i) {
           // throw in more pseudo random
           next = seed >>> (i << 3);
-          next ^= Math.floor(Math.random() * 0xFF);
+          next ^= Math.floor(Math.random() * 0x0100);
           b.putByte(String.fromCharCode(next & 0xFF));
         }
       }


### PR DESCRIPTION
the original multiplication will never reach 65535 resp. 255, because Math.random() generates a number between 0 inclusive and 1 exclusive.
By the way, I think some & 0xff are redundant, but with them the code is better comparable with David G. Carta's code. 
