### PR TITLE
Fix for node-webkit env

### DIFF
--- a/js/prng.js
+++ b/js/prng.js
@@ -17,7 +17,7 @@ var _nodejs = (
   typeof process !== 'undefined' && process.versions && process.versions.node);
 var crypto = null;
 if(!forge.disableNativeCode && _nodejs) {
-  crypto = require('crypto');
+  crypto = global.require('crypto');
 }
 
 /* PRNG API */


### PR DESCRIPTION
If you link forge with `<script>` inside of node-webkit, you still can run node.js code.
So don't try to load `crypto` with require.js and use node.js `require()` always.
