### PR TITLE
use issuer attributes in IssuerSerial certificate reference

### DIFF
--- a/js/pkcs7.js
+++ b/js/pkcs7.js
@@ -661,7 +661,7 @@ p7.createEnvelopedData = function() {
     addRecipient: function(cert) {
       msg.recipients.push({
         version: 0,
-        issuer: cert.subject.attributes,
+        issuer: cert.issuer.attributes,
         serialNumber: cert.serialNumber,
         encryptedContent: {
           // We simply assume rsaEncryption here, since forge.pki only


### PR DESCRIPTION
PKCS#7 envelopedData recipients should contain an IssuerSerial reference to the recipient certificate.

So the issuer field in the recipient should contain the issuer DN attributes instead of the subjectDN attributes.
