### PR TITLE
Use hardwareConcurrency when available

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -2785,7 +2785,7 @@ util.estimateCores = function(options, callback) {
     return callback(null, util.cores);
   }
   if(typeof navigator !== 'undefined' &&
-      navigator.hardwareConcurrency !== undefined &&
+      'hardwareConcurrency' in navigator &&
       navigator.hardwareConcurrency > 0) {
     util.cores = navigator.hardwareConcurrency;
     return callback(null, util.cores);


### PR DESCRIPTION
Use `navigator.hardwareConcurrency` when its available for `util.estimateCores`. Also fixed a few missing inverted commas around the typeof checks.

Not sure about coding style of the library in general but I tried to stick to the same sort of style that the code around it had. If you want me to change anything, just ask :+1: 

Closes #147
