### PR TITLE
update README.md: fixing incompatibility with Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,21 +850,23 @@ var decrypted = privateKey.decrypt(encrypted, 'RSA-OAEP', {
   md: forge.md.sha256.create()
 });
 
-// encrypt data with a public key using RSAES-OAEP/SHA-256/MGF1-SHA-1
-// compatible with Java's RSA/ECB/OAEPWithSHA-256AndMGF1Padding
+// encrypt data with a public key using RSAES-OAEP/SHA-256/MGF1-SHA-256
+// compatible with Java's RSA/ECB/OAEPWithSHA-256AndMGF1Padding (with 
+// the "BC" provider)
 var encrypted = publicKey.encrypt(bytes, 'RSA-OAEP', {
   md: forge.md.sha256.create(),
   mgf1: {
-    md: forge.md.sha1.create()
+    md: forge.md.sha256.create()
   }
 });
 
-// decrypt data with a private key using RSAES-OAEP/SHA-256/MGF1-SHA-1
-// compatible with Java's RSA/ECB/OAEPWithSHA-256AndMGF1Padding
+// decrypt data with a private key using RSAES-OAEP/SHA-256/MGF1-SHA-256
+// compatible with Java's RSA/ECB/OAEPWithSHA-256AndMGF1Padding (with 
+// the "BC" provider)
 var decrypted = privateKey.decrypt(encrypted, 'RSA-OAEP', {
   md: forge.md.sha256.create(),
   mgf1: {
-    md: forge.md.sha1.create()
+    md: forge.md.sha256.create()
   }
 });
 


### PR DESCRIPTION
Hi,

The example of RSA-OAEP encryption/decryption with SHA-256 and MGF1-SHA1 is not compatible with Java's RSA/ECB/OAEPWithSHA-256AndMGF1Padding (although this is claimed in the commend), at least for the BC provider (I have not checked it with any other providers). 

When changed to MGF1-SHA256, it becomes compatible with RSA/ECB/OAEPWithSHA-256AndMGF1Padding (with BC), as claimed.
