### PR TITLE
fix AES decipher iv transformation from byte array to byte buffer

### DIFF
--- a/js/cipherModes.js
+++ b/js/cipherModes.js
@@ -739,7 +739,7 @@ function transformIV(iv) {
     // convert iv byte array into byte buffer
     var tmp = iv;
     iv = forge.util.createBuffer();
-    for(var i = 0; i < iv.length; ++i) {
+    for(var i = 0; i < tmp.length; ++i) {
       iv.putByte(tmp[i]);
     }
   }


### PR DESCRIPTION
There's a bug in transformIV when the iv is given as a byte array. The resulting byte buffer is always empty. This fix transforms the iv byte array into the byte buffer correctly.

This fix is critical for production use! Please do your best to merge as soon as possible.