### PR TITLE
[WO-03-005] Fix off-by-one Error in Prime Worker Code of Forge library (Low)

### DIFF
--- a/js/jsbn.js
+++ b/js/jsbn.js
@@ -1198,7 +1198,7 @@ function bnGetPrng() {
     // x is an array to fill with bytes
     nextBytes: function(x) {
       for(var i = 0; i < x.length; ++i) {
-        x[i] = Math.floor(Math.random() * 0xFF);
+        x[i] = Math.floor(Math.random() * 0x0100);
       }
     }
   };


### PR DESCRIPTION
This bug was found by [Cure53](https://cure53.de) during a security review of [Whiteout Mail](https://whiteout.io). The following comments are copied from the audit report:

In the file forge/js/jsbn.js the method bnGetPrng() is present, tasked with generating a pseudo-random big number. This method is used during RSA key generation in the Miller Rabin pseudo-prime test. The following line gets a random number and converts it as uniformly distributed into a byte ([0..255]):

    x[i] = Math.floor(Math.random() * 0xFF);

Unfortunately the value of 255 will never be reached because Math.random() generates a value between 0 inclusive and 1 exclusive. This results in a subtle weakness in the Miller-Rabin pseudoprime test. It should be corrected to the following code:

    x[i] = Math.floor(Math.random() * 0x0100);

Note that here the astonishingly often despised call to Math.random() is acceptable because bnGetPrng() is only called to create the “witness” in the Miller Rabin test. If Math.random() was used for key creation, it would constitute a critical issue instead.