### PR TITLE
Generate public PEM from private key

### DIFF
--- a/js/rsa.js
+++ b/js/rsa.js
@@ -591,6 +591,14 @@ pki.setRsaPrivateKey = pki.rsa.setPrivateKey = function(
     return _rsaEncrypt(key, encoded, _rsaPrivateOp);
   };
 
+  key.toPublicPem = function(maxline) {
+    var pubKey = {
+      n: key.n,
+      e: key.e
+    }
+    return pki.publicKeyToPem(pubKey, maxline);
+  };
+
   return key;
 };
 

--- a/js/rsa.js
+++ b/js/rsa.js
@@ -591,6 +591,14 @@ pki.setRsaPrivateKey = pki.rsa.setPrivateKey = function(
     return _rsaEncrypt(key, encoded, _rsaPrivateOp);
   };
 
+  /**
+   * Creates a RSA public key from the modulus (n) and the public exponent (e)
+   * then converts the key to PEM format.
+   *
+   * @param maxline the maximum characters per line, defaults to 64.
+   *
+   * @return the PEM-formatted public key.
+   */
   key.toPublicPem = function(maxline) {
     var pubKey = {
       n: key.n,

--- a/nodejs/test/rsa.js
+++ b/nodejs/test/rsa.js
@@ -104,6 +104,11 @@ function Tests(ASSERT, PKI, RSA, MD, MGF, PSS, RANDOM, UTIL) {
       ASSERT.equal(PKI.publicKeyToPem(publicKey), _pem.publicKey);
     });
 
+    it('should convert private key to public PEM', function() {
+      var privateKey = PKI.privateKeyFromPem(_pem.privateKey);
+      ASSERT.equal(privateKey.toPublicPem(), _pem.publicKey);
+    });
+
     it('should convert a PKCS#8 PrivateKeyInfo to/from PEM', function() {
       var privateKey = PKI.privateKeyFromPem(_pem.privateKeyInfo);
       var rsaPrivateKey = PKI.privateKeyToAsn1(privateKey);


### PR DESCRIPTION
This makes it easier to share a public PEM derived from the private key.

Test is included.

Users can now store only the private key easily derive the public PEM on an as needed basis.