### PR TITLE
Match OpenSSL output for enveloped data

### DIFF
--- a/lib/pkcs7.js
+++ b/lib/pkcs7.js
@@ -1114,10 +1114,8 @@ function _encryptedContentToAsn1(ec) {
         ec.parameter.getBytes())
     ]),
     // [0] EncryptedContent
-    asn1.create(asn1.Class.CONTEXT_SPECIFIC, 0, true, [
-      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OCTETSTRING, false,
-        ec.content.getBytes())
-    ])
+    asn1.create(asn1.Class.CONTEXT_SPECIFIC, 0, false,
+      ec.content.getBytes())
   ];
 }
 


### PR DESCRIPTION
Do not include IMPLICIT ASN.1 elements in the output
