### PR TITLE
Optional verification of certificate validity date in certificate chain

### DIFF
--- a/js/tls.js
+++ b/js/tls.js
@@ -3545,7 +3545,7 @@ tls.verifyCertificateChain = function(c, chain) {
         }
 
         return ret;
-      });
+      }, c.verifyOptions);
   } catch(ex) {
     // build tls error if not already customized
     var err = ex;
@@ -3702,6 +3702,7 @@ tls.createConnection = function(options) {
     virtualHost: options.virtualHost || null,
     verifyClient: options.verifyClient || false,
     verify: options.verify || function(cn, vfd, dpth, cts) {return vfd;},
+    verifyOptions: options.verifyOptions||{},
     getCertificate: options.getCertificate || null,
     getPrivateKey: options.getPrivateKey || null,
     getSignature: options.getSignature || null,
@@ -4231,6 +4232,7 @@ forge.tls.createSessionCache = tls.createSessionCache;
  *   verifyClient: true to require a client certificate in server mode,
  *     'optional' to request one, false not to (default: false).
  *   verify: a handler used to custom verify certificates in the chain.
+ *   verifyOptions: an object object with options for the certificate chain validation 
  *   getCertificate: an optional callback used to get a certificate or
  *     a chain of certificates (as an array).
  *   getPrivateKey: an optional callback used to get a private key.

--- a/js/x509.js
+++ b/js/x509.js
@@ -2751,6 +2751,8 @@ pki.certificateError = {
  * @param chain the certificate chain to verify, with the root or highest
  *          authority at the end (an array of certificates).
  * @param verify called for every certificate in the chain.
+ * @param the options to use.
+ *        [skipValidityPeriod] whether to skip the validity period check
  *
  * The verify callback has the following signature:
  *
@@ -2766,7 +2768,7 @@ pki.certificateError = {
  *
  * @return true if successful, error thrown if not.
  */
-pki.verifyCertificateChain = function(caStore, chain, verify) {
+pki.verifyCertificateChain = function(caStore, chain, verify, options) {
   /* From: RFC3280 - Internet X.509 Public Key Infrastructure Certificate
     Section 6: Certification Path Validation
     See inline parentheticals related to this particular implementation.
@@ -2896,6 +2898,12 @@ pki.verifyCertificateChain = function(caStore, chain, verify) {
        CAs that may appear below a CA before only end-entity certificates
        may be issued. */
 
+  // validation options
+  options = options||{};
+  var opts = {
+    skipValidityPeriod: options.skipValidityPeriod===true
+  };
+
   // copy cert chain references to another array to protect against changes
   // in verify callback
   chain = chain.slice(0);
@@ -2915,7 +2923,7 @@ pki.verifyCertificateChain = function(caStore, chain, verify) {
     var selfSigned = false;
 
     // 1. check valid time
-    if(now < cert.validity.notBefore || now > cert.validity.notAfter) {
+    if(!opts.skipValidityPeriod && (now < cert.validity.notBefore || now > cert.validity.notAfter)) {
       error = {
         message: 'Certificate is not valid yet or has expired.',
         error: pki.certificateError.certificate_expired,


### PR DESCRIPTION
pki.verifyCertificateChain method now has optional parameter to skip validity period check. Furthermore, added verifyOptions to tls connection so we can skip this verification step when we setup a tls connection.