### PR TITLE
Clarify the Certificate is not trusted Error.

### DIFF
--- a/js/x509.js
+++ b/js/x509.js
@@ -2973,7 +2973,7 @@ pki.verifyCertificateChain = function(caStore, chain, verify) {
         !caStore.hasCertificate(cert)) {
         // no parent issuer and certificate itself is not trusted
         error = {
-          message: 'Certificate is not trusted.',
+          message: 'Certificate is not trusted. A matching CA cert could not be found by subject or the DER-encoding did not match the CA certificate.',
           error: pki.certificateError.unknown_ca
         };
       }


### PR DESCRIPTION
I was working with the library and ran into the 'Certificate is not trusted Error'.There was a CN mismatch, but not being familiar with the library I was unsure what this error message meant or why the certificate was not trusted.  After some debugging I discovered it was a subject mismatch and a matching certificate was not found in the caStore.

This PR modified the error message to identify the possible issues to a consumer. 

I'm not very satisfied with the error message. It represents two possible error cases and is much longer than the other error conditions. It would be nice to separate DER validation from the caStore.hasCertificate method, so this error messaged could be more concise. 

I cannot pursue refactoring hasCertificate at the moment, so I am proposing just updating the error message for now. If the changes would be welcome open an issue and assign it to me. I'll try to get around to it when time allows.
