### PR TITLE
Remove redundant MGF1 implementation + allow MGF injection

### DIFF
--- a/nodejs/test/pkcs1.js
+++ b/nodejs/test/pkcs1.js
@@ -53,8 +53,8 @@ function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL) {
       ASSERT.equal(message, decoded);
     });
 
-    testOAEP();
-    testOAEPSHA256();
+    describe('RSAES-OAEP encryption examples with SHA-1 digest', testOAEP);
+    describe('RSAES-OAEP encryption examples with SHA-256 digest', testOAEPSHA256);
 
     function testOAEP() {
       var modulus, exponent, d, p, q, dP, dQ, qInv, pubkey, privateKey;

--- a/nodejs/test/pkcs1.js
+++ b/nodejs/test/pkcs1.js
@@ -1147,6 +1147,28 @@ function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL, MGF1) {
             var ciphertext = pubkey.encrypt(encoded, null);
             ASSERT.equal(encrypted, UTIL.encode64(ciphertext));
         });
+
+        it('should throw if message is too long', function() {
+            // key = 128 bytes, digest = 32 bytes * 2, 2 bytes extra -> max length = 62 bytes
+            // -> providing 63 bytes must throw
+            var message = '123456789012345678901234567890123456789012345678901234567890123';
+            var seed = UTIL.decode64('GLd26iEGnWl3ajPpa61I4d2gpe8Yt3bqIQadaXdqM+k=');
+
+            var md = MD.sha256.create();
+            ASSERT.throws(function() {
+                PKCS1.encode_rsa_oaep(pubkey, message, {seed: seed, md: md});
+              }, Error);
+        });
+
+        it('should throw if seed length != digest length', function() {
+            var message = UTIL.decode64('ZigZThIHPbA7qUzanvlTI5fVDbp5uYcASv7+NA==');
+            var seed = 'hello world';
+
+            var md = MD.sha256.create();
+            ASSERT.throws(function() {
+                PKCS1.encode_rsa_oaep(pubkey, message, {seed: seed, md: md});
+              }, Error);
+        });
     });
 
     describe('decode_rsa_oaep', function() {
@@ -1215,6 +1237,14 @@ function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL, MGF1) {
             var decrypted = privateKey.decrypt(encrypted, null);
             var decoded = PKCS1.decode_rsa_oaep(privateKey, decrypted, {md: md, mgf: mgf});
             ASSERT.equal(message, decoded);
+        });
+
+        it('should throw if input length != key length', function() {
+            var message = 'anything not 128 chars long';
+
+            ASSERT.throws(function() {
+                PKCS1.decode_rsa_oaep(privateKey, message);
+              }, Error);
         });
     });
   });

--- a/nodejs/test/pkcs1.js
+++ b/nodejs/test/pkcs1.js
@@ -1,6 +1,6 @@
 (function() {
 
-function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL) {
+function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL, MGF1) {
   var BigInteger = JSBN.BigInteger;
 
   // RSA's test vectors for Forge's RSA-OAEP implementation:
@@ -1134,6 +1134,19 @@ function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL) {
             var ciphertext = pubkey.encrypt(encoded, null);
             ASSERT.equal(encrypted, UTIL.encode64(ciphertext));
         });
+
+        it('should allow to pass own mgf', function() {
+            var message = UTIL.decode64('ZigZThIHPbA7qUzanvlTI5fVDbp5uYcASv7+NA==');
+            var seed = UTIL.decode64('GLd26iEGnWl3ajPpa61I4d2gpe8=');
+            var encrypted = 'lYWO+NacwIhkuixMMVULZjw9FYwWce3cl/YqnhfrBsab57btsvXfYa3TV1VJ+G++DqpqLpftMfUnODlI4FSDMHZsQqa5Da+G07S3p8eJ0DqzAum3euO+Cbi74Do2wOzIHLL31EN70/SUuVAn5PTBZPyOM6hGHz+EZmIsL0rB0v0=';
+
+            var md = MD.sha1.create();
+            var mgf = MGF1.create(MD.sha256.create());
+            var encoded = PKCS1.encode_rsa_oaep(
+              pubkey, message, {seed: seed, md: md, mgf: mgf });
+            var ciphertext = pubkey.encrypt(encoded, null);
+            ASSERT.equal(encrypted, UTIL.encode64(ciphertext));
+        });
     });
 
     describe('decode_rsa_oaep', function() {
@@ -1192,6 +1205,17 @@ function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL) {
             var decoded = PKCS1.decode_rsa_oaep(privateKey, decrypted, {md: md, mgf1: {md: mgfMd}});
             ASSERT.equal(message, decoded);
         });
+
+        it('should allow to pass own mgf', function() {
+            var message = UTIL.decode64('ZigZThIHPbA7qUzanvlTI5fVDbp5uYcASv7+NA==');
+            var encrypted = UTIL.decode64('lYWO+NacwIhkuixMMVULZjw9FYwWce3cl/YqnhfrBsab57btsvXfYa3TV1VJ+G++DqpqLpftMfUnODlI4FSDMHZsQqa5Da+G07S3p8eJ0DqzAum3euO+Cbi74Do2wOzIHLL31EN70/SUuVAn5PTBZPyOM6hGHz+EZmIsL0rB0v0=');
+
+            var md = MD.sha1.create();
+            var mgf = MGF1.create(MD.sha256.create());
+            var decrypted = privateKey.decrypt(encrypted, null);
+            var decoded = PKCS1.decode_rsa_oaep(privateKey, decrypted, {md: md, mgf: mgf});
+            ASSERT.equal(message, decoded);
+        });
     });
   });
 }
@@ -1203,8 +1227,9 @@ if(typeof define === 'function') {
     'forge/pkcs1',
     'forge/md',
     'forge/jsbn',
-    'forge/util'
-  ], function(PKI, PKCS1, MD, JSBN, UTIL) {
+    'forge/util',
+    'forge/mgf1'
+  ], function(PKI, PKCS1, MD, JSBN, UTIL, MGF1) {
     Tests(
       // Global provided by test harness
       ASSERT,
@@ -1212,7 +1237,8 @@ if(typeof define === 'function') {
       PKCS1(),
       MD(),
       JSBN(),
-      UTIL()
+      UTIL(),
+      MGF1()
     );
   });
 } else if(typeof module === 'object' && module.exports) {
@@ -1223,7 +1249,8 @@ if(typeof define === 'function') {
     require('../../js/pkcs1')(),
     require('../../js/md')(),
     require('../../js/jsbn')(),
-    require('../../js/util')());
+    require('../../js/util')(),
+    require('../../js/mgf1')());
 }
 
 })();


### PR DESCRIPTION
The PKCS#1 module currently has its own `rsa_mgf1` implementation, even so we have a seperate MGF1 module. This patch primarily aims add removing the former.

Being at it and as the OAEP code currently hard codes MGF1 (opposed to RFC 3447 which generally considers different MGFs) I changed the API in such a way, that the MGF can be injected.
For backwards compatibility the old call schemes are still supported and lead to on-the-fly creation of MGF1 module instances as needed.

Besides I've added further tests on PKCS#1 module to especially cover the exception branches as well as all possible (legacy) call/argument schemes.