### PR TITLE
CMS/PKCS#7 support for RSAES-OAEP

### DIFF
--- a/js/mgf1.js
+++ b/js/mgf1.js
@@ -23,6 +23,9 @@ var mgf1 = forge.mgf.mgf1 = forge.mgf1 = forge.mgf1 || {};
  */
 mgf1.create = function(md) {
   var mgf = {
+    algorithm: 'mgf1',
+    md: md,
+
     /**
      * Generate mask of specified length.
      *

--- a/js/pkcs7.js
+++ b/js/pkcs7.js
@@ -688,8 +688,8 @@ p7.createEnvelopedData = function() {
       var schemeOptions;
 
       if(options) {
-	algorithm = options.algorithm || undefined;
-	schemeOptions = options.schemeOptions || undefined;
+        algorithm = options.algorithm || undefined;
+        schemeOptions = options.schemeOptions || undefined;
       }
 
       msg.recipients.push({
@@ -698,7 +698,7 @@ p7.createEnvelopedData = function() {
         serialNumber: cert.serialNumber,
         encryptedContent: {
           algorithm: algorithm || forge.pki.oids.rsaEncryption,
-	  schemeOptions: schemeOptions || {},
+          schemeOptions: schemeOptions || {},
           key: cert.publicKey
         }
       });
@@ -796,11 +796,11 @@ p7.createEnvelopedData = function() {
                 msg.encryptedContent.key.data);
             break;
 
-	  case forge.pki.oids['RSAES-OAEP']:
+          case forge.pki.oids['RSAES-OAEP']:
             recipient.encryptedContent.content =
               recipient.encryptedContent.key.encrypt(
                 msg.encryptedContent.key.data, 'RSAES-OAEP',
-		recipient.encryptedContent.schemeOptions);
+                recipient.encryptedContent.schemeOptions);
             break;
 
           default:
@@ -972,7 +972,7 @@ function _encAlgorithmParametersToAsn1(encryptedContent) {
 
     default:
       throw new Error('Unsupported asymmetric cipher, OID ' +
-	encryptedContent.algorithm);
+        encryptedContent.algorithm);
   }
 }
 

--- a/js/pkcs7.js
+++ b/js/pkcs7.js
@@ -941,8 +941,11 @@ function _encAlgorithmParametersToAsn1(encryptedContent) {
       if(encryptedContent.schemeOptions.md
           && encryptedContent.schemeOptions.md.algorithm
           && encryptedContent.schemeOptions.md.algorithm !== 'sha1') {
-        seq.value.push(asn1.create(asn1.Class.CONTEXT_SPECIFIC, 0, true,
-          _encodeMdAlgorithmToAsn1(encryptedContent.schemeOptions.md)));
+        seq.value.push(asn1.create(asn1.Class.CONTEXT_SPECIFIC, 0, true, [
+          asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true,
+            _encodeMdAlgorithmToAsn1(encryptedContent.schemeOptions.md)
+          )
+        ]));
       }
 
       if(encryptedContent.schemeOptions.mgf
@@ -950,14 +953,16 @@ function _encAlgorithmParametersToAsn1(encryptedContent) {
           && (encryptedContent.schemeOptions.mgf.algorithm !== 'mgf1'
               || encryptedContent.schemeOptions.mgf.md.algorithm != 'sha1')) {
         seq.value.push(asn1.create(asn1.Class.CONTEXT_SPECIFIC, 1, true, [
-          // Algorithm
-          asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OID, false,
-            asn1.oidToDer(
-              forge.oids[encryptedContent.schemeOptions.mgf.algorithm]
-            ).getBytes()),
-          // Parameter
-          asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true,
-            _encodeMdAlgorithmToAsn1(encryptedContent.schemeOptions.mgf.md))
+          asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+            // Algorithm
+            asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OID, false,
+              asn1.oidToDer(
+                forge.oids[encryptedContent.schemeOptions.mgf.algorithm]
+              ).getBytes()),
+            // Parameter
+            asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true,
+              _encodeMdAlgorithmToAsn1(encryptedContent.schemeOptions.mgf.md))
+          ])
         ]));
       }
 

--- a/js/pkcs7asn1.js
+++ b/js/pkcs7asn1.js
@@ -419,11 +419,16 @@ p7v.oaepParametersValidator = {
     constructed: true,
     optional: true,
     value: [{
-      name: 'hashFunc.Algorithm',
       tagClass: asn1.Class.UNIVERSAL,
-      type: asn1.Type.OID,
-      constructed: false,
-      capture: 'digestAlgorithm'
+      type: asn1.Type.SEQUENCE,
+      constructed: true,
+      value: [{
+        name: 'hashFunc.Algorithm',
+        tagClass: asn1.Class.UNIVERSAL,
+        type: asn1.Type.OID,
+        constructed: false,
+        capture: 'digestAlgorithm'
+      }]
     }]
   }, {
     name: 'maskGenFunc',
@@ -432,22 +437,27 @@ p7v.oaepParametersValidator = {
     constructed: true,
     optional: true,
     value: [{
-      name: 'maskGenFunc.Algorithm',
-      tagClass: asn1.Class.UNIVERSAL,
-      type: asn1.Type.OID,
-      constructed: false,
-      capture: 'mgfAlgorithm'
-    }, {
-      name: 'maskGenFunc.Parameters',
       tagClass: asn1.Class.UNIVERSAL,
       type: asn1.Type.SEQUENCE,
       constructed: true,
       value: [{
-        name: 'maskGenFunc.Parameters.Algorithm',
+        name: 'maskGenFunc.Algorithm',
         tagClass: asn1.Class.UNIVERSAL,
         type: asn1.Type.OID,
         constructed: false,
-        capture: 'mgfDigestAlgorithm'
+        capture: 'mgfAlgorithm'
+      }, {
+        name: 'maskGenFunc.Parameters',
+        tagClass: asn1.Class.UNIVERSAL,
+        type: asn1.Type.SEQUENCE,
+        constructed: true,
+        value: [{
+          name: 'maskGenFunc.Parameters.Algorithm',
+          tagClass: asn1.Class.UNIVERSAL,
+          type: asn1.Type.OID,
+          constructed: false,
+          capture: 'mgfDigestAlgorithm'
+        }]
       }]
     }]
   }]

--- a/js/pkcs7asn1.js
+++ b/js/pkcs7asn1.js
@@ -5,7 +5,7 @@
  * @author Stefan Siegl
  *
  * Copyright (c) 2012-2015 Digital Bazaar, Inc.
- * Copyright (c) 2012 Stefan Siegl <stesie@brokenpipe.de>
+ * Copyright (c) 2012, 2015 Stefan Siegl <stesie@brokenpipe.de>
  *
  * The ASN.1 representation of PKCS#7 is as follows
  * (see RFC #2315 for details, http://www.ietf.org/rfc/rfc2315.txt):
@@ -396,7 +396,6 @@ p7v.recipientInfoValidator = {
     }, {
       name: 'RecipientInfo.keyEncryptionAlgorithm.parameter',
       tagClass: asn1.Class.UNIVERSAL,
-      constructed: false,
       captureAsn1: 'encParameter'
     }]
   }, {
@@ -405,6 +404,52 @@ p7v.recipientInfoValidator = {
     type: asn1.Type.OCTETSTRING,
     constructed: false,
     capture: 'encKey'
+  }]
+};
+
+p7v.oaepParametersValidator = {
+  name: 'oaepParameters',
+  tagClass: asn1.Class.UNIVERSAL,
+  type: asn1.Type.SEQUENCE,
+  constructed: true,
+  value: [{
+    name: 'hashFunc',
+    tagClass: asn1.Class.CONTEXT_SPECIFIC,
+    type: 0,
+    constructed: true,
+    optional: true,
+    value: [{
+      name: 'hashFunc.Algorithm',
+      tagClass: asn1.Class.UNIVERSAL,
+      type: asn1.Type.OID,
+      constructed: false,
+      capture: 'digestAlgorithm'
+    }]
+  }, {
+    name: 'maskGenFunc',
+    tagClass: asn1.Class.CONTEXT_SPECIFIC,
+    type: 1,
+    constructed: true,
+    optional: true,
+    value: [{
+      name: 'maskGenFunc.Algorithm',
+      tagClass: asn1.Class.UNIVERSAL,
+      type: asn1.Type.OID,
+      constructed: false,
+      capture: 'mgfAlgorithm'
+    }, {
+      name: 'maskGenFunc.Parameters',
+      tagClass: asn1.Class.UNIVERSAL,
+      type: asn1.Type.SEQUENCE,
+      constructed: true,
+      value: [{
+        name: 'maskGenFunc.Parameters.Algorithm',
+        tagClass: asn1.Class.UNIVERSAL,
+        type: asn1.Type.OID,
+        constructed: false,
+        capture: 'mgfDigestAlgorithm'
+      }]
+    }]
   }]
 };
 

--- a/nodejs/test/pkcs1.js
+++ b/nodejs/test/pkcs1.js
@@ -53,8 +53,8 @@ function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL) {
       ASSERT.equal(message, decoded);
     });
 
-    testOAEP();
-    testOAEPSHA256();
+    describe('RSAES-OAEP encryption examples with SHA-1 digest', testOAEP);
+    describe('RSAES-OAEP encryption examples with SHA-256 digest', testOAEPSHA256);
 
     function testOAEP() {
       var modulus, exponent, d, p, q, dP, dQ, qInv, pubkey, privateKey;

--- a/nodejs/test/pkcs1.js
+++ b/nodejs/test/pkcs1.js
@@ -1147,6 +1147,28 @@ function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL, MGF1) {
             var ciphertext = pubkey.encrypt(encoded, null);
             ASSERT.equal(encrypted, UTIL.encode64(ciphertext));
         });
+
+        it('should throw if message is too long', function() {
+            // key = 128 bytes, digest = 32 bytes * 2, 2 bytes extra -> max length = 62 bytes
+            // -> providing 63 bytes must throw
+            var message = '123456789012345678901234567890123456789012345678901234567890123';
+            var seed = UTIL.decode64('GLd26iEGnWl3ajPpa61I4d2gpe8Yt3bqIQadaXdqM+k=');
+
+            var md = MD.sha256.create();
+            ASSERT.throws(function() {
+                PKCS1.encode_rsa_oaep(pubkey, message, {seed: seed, md: md});
+              }, Error);
+        });
+
+        it('should throw if seed length != digest length', function() {
+            var message = UTIL.decode64('ZigZThIHPbA7qUzanvlTI5fVDbp5uYcASv7+NA==');
+            var seed = 'hello world';
+
+            var md = MD.sha256.create();
+            ASSERT.throws(function() {
+                PKCS1.encode_rsa_oaep(pubkey, message, {seed: seed, md: md});
+              }, Error);
+        });
     });
 
     describe('decode_rsa_oaep', function() {
@@ -1215,6 +1237,14 @@ function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL, MGF1) {
             var decrypted = privateKey.decrypt(encrypted, null);
             var decoded = PKCS1.decode_rsa_oaep(privateKey, decrypted, {md: md, mgf: mgf});
             ASSERT.equal(message, decoded);
+        });
+
+        it('should throw if input length != key length', function() {
+            var message = 'anything not 128 chars long';
+
+            ASSERT.throws(function() {
+                PKCS1.decode_rsa_oaep(privateKey, message);
+              }, Error);
         });
     });
   });

--- a/nodejs/test/pkcs1.js
+++ b/nodejs/test/pkcs1.js
@@ -1,6 +1,6 @@
 (function() {
 
-function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL) {
+function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL, MGF1) {
   var BigInteger = JSBN.BigInteger;
 
   // RSA's test vectors for Forge's RSA-OAEP implementation:
@@ -1134,6 +1134,19 @@ function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL) {
             var ciphertext = pubkey.encrypt(encoded, null);
             ASSERT.equal(encrypted, UTIL.encode64(ciphertext));
         });
+
+        it('should allow to pass own mgf', function() {
+            var message = UTIL.decode64('ZigZThIHPbA7qUzanvlTI5fVDbp5uYcASv7+NA==');
+            var seed = UTIL.decode64('GLd26iEGnWl3ajPpa61I4d2gpe8=');
+            var encrypted = 'lYWO+NacwIhkuixMMVULZjw9FYwWce3cl/YqnhfrBsab57btsvXfYa3TV1VJ+G++DqpqLpftMfUnODlI4FSDMHZsQqa5Da+G07S3p8eJ0DqzAum3euO+Cbi74Do2wOzIHLL31EN70/SUuVAn5PTBZPyOM6hGHz+EZmIsL0rB0v0=';
+
+            var md = MD.sha1.create();
+            var mgf = MGF1.create(MD.sha256.create());
+            var encoded = PKCS1.encode_rsa_oaep(
+              pubkey, message, {seed: seed, md: md, mgf: mgf });
+            var ciphertext = pubkey.encrypt(encoded, null);
+            ASSERT.equal(encrypted, UTIL.encode64(ciphertext));
+        });
     });
 
     describe('decode_rsa_oaep', function() {
@@ -1192,6 +1205,17 @@ function Tests(ASSERT, PKI, PKCS1, MD, JSBN, UTIL) {
             var decoded = PKCS1.decode_rsa_oaep(privateKey, decrypted, {md: md, mgf1: {md: mgfMd}});
             ASSERT.equal(message, decoded);
         });
+
+        it('should allow to pass own mgf', function() {
+            var message = UTIL.decode64('ZigZThIHPbA7qUzanvlTI5fVDbp5uYcASv7+NA==');
+            var encrypted = UTIL.decode64('lYWO+NacwIhkuixMMVULZjw9FYwWce3cl/YqnhfrBsab57btsvXfYa3TV1VJ+G++DqpqLpftMfUnODlI4FSDMHZsQqa5Da+G07S3p8eJ0DqzAum3euO+Cbi74Do2wOzIHLL31EN70/SUuVAn5PTBZPyOM6hGHz+EZmIsL0rB0v0=');
+
+            var md = MD.sha1.create();
+            var mgf = MGF1.create(MD.sha256.create());
+            var decrypted = privateKey.decrypt(encrypted, null);
+            var decoded = PKCS1.decode_rsa_oaep(privateKey, decrypted, {md: md, mgf: mgf});
+            ASSERT.equal(message, decoded);
+        });
     });
   });
 }
@@ -1203,8 +1227,9 @@ if(typeof define === 'function') {
     'forge/pkcs1',
     'forge/md',
     'forge/jsbn',
-    'forge/util'
-  ], function(PKI, PKCS1, MD, JSBN, UTIL) {
+    'forge/util',
+    'forge/mgf1'
+  ], function(PKI, PKCS1, MD, JSBN, UTIL, MGF1) {
     Tests(
       // Global provided by test harness
       ASSERT,
@@ -1212,7 +1237,8 @@ if(typeof define === 'function') {
       PKCS1(),
       MD(),
       JSBN(),
-      UTIL()
+      UTIL(),
+      MGF1()
     );
   });
 } else if(typeof module === 'object' && module.exports) {
@@ -1223,7 +1249,8 @@ if(typeof define === 'function') {
     require('../../js/pkcs1')(),
     require('../../js/md')(),
     require('../../js/jsbn')(),
-    require('../../js/util')());
+    require('../../js/util')(),
+    require('../../js/mgf1')());
 }
 
 })();

--- a/nodejs/test/pkcs7.js
+++ b/nodejs/test/pkcs7.js
@@ -380,7 +380,7 @@ function Tests(ASSERT, PKCS7, PKI, AES, DES, MGF1, MD, UTIL) {
 
         // hashFunc is SHA-256, i.e. not default -> expect [0]
         ASSERT.equal(options.value[0].tagClass, forge.asn1.Class.CONTEXT_SPECIFIC);
-        var hashFunc = options.value[0].value;
+        var hashFunc = options.value[0].value[0].value;
 
         // AlgorithmIdentifier.Algorithm must be SHA-256
         ASSERT.equal(forge.asn1.derToOid(hashFunc[0].value),
@@ -464,9 +464,11 @@ function Tests(ASSERT, PKCS7, PKI, AES, DES, MGF1, MD, UTIL) {
         ASSERT.equal(options.type, forge.asn1.Type.SEQUENCE);
         ASSERT.equal(options.value.length, 2); // Digest + MGF option
 
-        // maskGenFunc is MGF1(SHA-256), i.e. not default -> expect [1]
+        // maskGenFunc is MGF1(SHA-256), i.e. not default -> expect [1] SEQUENCE
         ASSERT.equal(options.value[1].tagClass, forge.asn1.Class.CONTEXT_SPECIFIC);
-        var maskGenFunc = options.value[1].value;
+        ASSERT.equal(options.value[1].value[0].type, forge.asn1.Type.SEQUENCE);
+
+        var maskGenFunc = options.value[1].value[0].value;
         ASSERT.equal(maskGenFunc.length, 2);
 
         // AlgorithmIdentifier.Algorithm must be MGF1

--- a/nodejs/test/pkcs7.js
+++ b/nodejs/test/pkcs7.js
@@ -488,6 +488,25 @@ function Tests(ASSERT, PKCS7, PKI, AES, DES, MGF1, MD, UTIL) {
         ASSERT.equal(hashFunc[1].type, forge.asn1.Type.NULL);
       });
 
+      it('should export message to PEM', function() {
+        var p7 = PKCS7.createEnvelopedData();
+        p7.addRecipient(PKI.certificateFromPem(_pem.certificate), {
+          algorithm: forge.pki.oids['RSAES-OAEP'],
+          schemeOptions: {
+            md: MD.sha256.create(),
+            mgf: MGF1.create(MD.sha256.create())
+          }
+        });
+        p7.content = UTIL.createBuffer('Just a little test');
+        p7.encrypt();
+
+        var pem = PKCS7.messageToPem(p7);
+
+        // convert back from PEM to new PKCS#7 object, decrypt, and test
+        p7 = PKCS7.messageFromPem(pem);
+        p7.decrypt(p7.recipients[0], PKI.privateKeyFromPem(_pem.privateKey));
+        ASSERT.equal(p7.content, 'Just a little test');
+      });
     });
 
     it('should aes-encrypt a message', function() {


### PR DESCRIPTION
This pull request is based on my previous pull request #288.

Goal of this change is to be able to create Enveloped-Data messages in CMS syntax (RFC 5652) using the RSA-OAEP encryption scheme. After all CMS is a successor of PKCS#7 v1.5 which probably justifies for a seperate module in forge. However I'm currently not willing to implement whole CMS stuff but just the Enveloped-Data thing like PKCS#7 with RSAES-OAEP ... which actually looks like PKCS#7, even has the version number untouched, solely a different RSAES.

... hence I decided *not* to create a new CMS module which effectively would be either a copy of PKCS#7 module (or some common subset) ... but instead augment the PKCS#7 module. This is latter module now allows to pass `algorithm` and `schemeOptions` options to its `addRecipient` method and handles them by considering changes from RFC 5652 + handling reverse direction.

Besides I changed the public API of MGF1 module so it has two new public attributes:
* `algorithm` set to "mgf1", so a MGF object tells its type (like the MD objects do)
* `md` allowing to access the MD injected with the `create` call

... both are needed so the PKCS#7 module can access the info that it has to encode into the CMS structure.