### PR TITLE
JSBN: - fixes off by one error in #bnpFromInt()

### DIFF
--- a/js/jsbn.js
+++ b/js/jsbn.js
@@ -170,7 +170,7 @@ function bnpFromInt(x) {
   this.t = 1;
   this.s = (x<0)?-1:0;
   if(x > 0) this.data[0] = x;
-  else if(x < -1) this.data[0] = x+this.DV;
+  else if(x <= -1) this.data[0] = x+this.DV;
   else this.t = 0;
 }
 
@@ -361,7 +361,7 @@ function bnpSubTo(a,r) {
     c -= a.s;
   }
   r.s = (c<0)?-1:0;
-  if(c < -1) r.data[i++] = this.DV+c;
+  if(c <= -1) r.data[i++] = this.DV+c;
   else if(c > 0) r.data[i++] = c;
   r.t = i;
   r.clamp();
@@ -881,7 +881,7 @@ if(a.t < this.t) {
 }
 r.s = (c<0)?-1:0;
 if(c > 0) r.data[i++] = c;
-else if(c < -1) r.data[i++] = this.DV+c;
+else if(c <= -1) r.data[i++] = this.DV+c;
 r.t = i;
 r.clamp();
 }


### PR DESCRIPTION
Just played with jsbn.js and discovered an off by one in bnpFromInt() through some unit tests. (Always asume BigInteger.DB == 26)

#### Problem
A *-1* as input parameter is not properly converted and stored as *BigInteger {0: 0, t: 0, s: -1}* but it should be *BigInteger {0: 67108863, t: 1, s: -1}*.

```javascript
var bigInt =  new BigInteger(null);
bigInt.fromInt(-1);

/// bigInt is now BigInteger {0: 0, t: 0, s: -1} instead of BigInteger {0: 67108863, t: 1, s: -1}*

var byteArray = bigInt.toByteArray();       /// [-1] instead of the expected [255, 255, 255]
var binString = util.bin2str(byteArray);     /// '￿' instead of the expected 'ÿÿÿ'
```

#### Further Problems

Even after a fix of bnpAddTo() and bnpSubTo() these methods do not generate proper results. I maybe discovered a second flaw in bnpClamp() after some tests with bnpFromString():

```javascript
var bigIntFromString = new BigInteger(null);
bigIntFromString.fromString("-1", 10);

/// bigInt is now BigInteger {0: 67108863, t: 0, s: -1} instead of BigInteger {0: 67108863, t: 1, s: -1}*
```

As you can see bnpFromString() results in a proper data and s flag but the t value is wrong. This is a direct result of the clamping operation at the end of bnpString() (which is also called at the end of bnpAddTo() and bnpSubTo()).

```javascript
// (protected) clamp off excess high words
function bnpClamp() {
  var c = this.s&this.DM;
 while(this.t > 0 && this.data[this.t-1] == c) --this.t;
}

/// for dbits = 26
/// > s == -1 for negative numbers, DM == (1<<26)-1
/// > c == 67108863
/// t will be reduced to 0
```

When the current number is negativ the c-variable is always set to the same value that represents a minus one (like 67108863 for BigInteger.DB == 26). If I now use clamp() on -1 (BigInteger {0: 67108863, t: 1, s: -1}) or sth. bigger with all bits set like BigInteger {0: 67108863, 1: 67108863, t: 2, s: -1} this numbers are always reduced to BigInteger {0: 67108863, t: 0, s: -1} which should be the representation of -0 and not -1.

#### Additions
This error also ocures in the original library published by Tom Wu but i couldn't ask him directly because his mailbox is full.