### PR TITLE
More intuitive API for authorityKeyIdentifier extension

### DIFF
--- a/js/x509.js
+++ b/js/x509.js
@@ -2294,10 +2294,8 @@ function _fillMissingExtensionFields(e, options) {
     if(e.authorityCertIssuer) {
       var authorityCertIssuer = [
         asn1.create(asn1.Class.CONTEXT_SPECIFIC, 4, true, [
-          _dnToAsn1({
-            attributes: (e.authorityCertIssuer === true ?
-              options.cert.issuer.attributes : e.authorityCertIssuer)
-            })
+          _dnToAsn1(e.authorityCertIssuer === true ?
+            options.cert.issuer : e.authorityCertIssuer)
         ])
       ];
       seq.push(


### PR DESCRIPTION
While I was playing with signing certificates, it occurred that I may have made a poor API choice.

The API (using non-default values) would looks like:

```
{
              name: 'authorityKeyIdentifier',
              keyIdentifier: this._ca.cert.generateSubjectKeyIdentifier().getBytes(),
              authorityCertIssuer: this._ca.cert.issuer,
              serialNumber: this._ca.cert.serialNumber
            }
```

Currently it requires `authorityCertIssuer: this._ca.cert.issuer.attributes`.
It's a minor but breaking change, so I guess it's best to fix it asap.