### PR TITLE
Invalid empty tls messages

### DIFF
--- a/js/tls.js
+++ b/js/tls.js
@@ -3377,8 +3377,8 @@ tls.queue = function(c, record) {
     return;
   }
 
-  if (record.fragment.length() == 0) {
-    if (record.type === tls.ContentType.handshake ||
+  if(record.fragment.length() === 0) {
+    if(record.type === tls.ContentType.handshake ||
       record.type === tls.ContentType.alert ||
       record.type === tls.ContentType.change_cipher_spec) {
       // Empty handshake, alert of change cipher spec messages are not allowed per the TLS specification and should not be sent.

--- a/js/tls.js
+++ b/js/tls.js
@@ -3377,6 +3377,14 @@ tls.queue = function(c, record) {
     return;
   }
 
+  if (record.fragment.length == 0) {
+    if (record.type === tls.contentType.handshake ||
+      record.type === tls.contentType.alert ||
+      record.type === tls.contentType.change_cipher_spec) {
+    // Empty handshake, alert of change cipher spec messages are not allowed per the TLS specification and should not be sent.
+    return;
+  }
+
   // if the record is a handshake record, update handshake hashes
   if(record.type === tls.ContentType.handshake) {
     var bytes = record.fragment.bytes();

--- a/js/tls.js
+++ b/js/tls.js
@@ -3378,9 +3378,9 @@ tls.queue = function(c, record) {
   }
 
   if (record.fragment.length() == 0) {
-    if (record.type === tls.contentType.handshake ||
-      record.type === tls.contentType.alert ||
-      record.type === tls.contentType.change_cipher_spec) {
+    if (record.type === tls.ContentType.handshake ||
+      record.type === tls.ContentType.alert ||
+      record.type === tls.ContentType.change_cipher_spec) {
       // Empty handshake, alert of change cipher spec messages are not allowed per the TLS specification and should not be sent.
       return;
     }

--- a/js/tls.js
+++ b/js/tls.js
@@ -3377,7 +3377,7 @@ tls.queue = function(c, record) {
     return;
   }
 
-  if (record.fragment.length == 0) {
+  if (record.fragment.length() == 0) {
     if (record.type === tls.contentType.handshake ||
       record.type === tls.contentType.alert ||
       record.type === tls.contentType.change_cipher_spec) {

--- a/js/tls.js
+++ b/js/tls.js
@@ -3381,8 +3381,9 @@ tls.queue = function(c, record) {
     if (record.type === tls.contentType.handshake ||
       record.type === tls.contentType.alert ||
       record.type === tls.contentType.change_cipher_spec) {
-    // Empty handshake, alert of change cipher spec messages are not allowed per the TLS specification and should not be sent.
-    return;
+      // Empty handshake, alert of change cipher spec messages are not allowed per the TLS specification and should not be sent.
+      return;
+    }
   }
 
   // if the record is a handshake record, update handshake hashes


### PR DESCRIPTION
TLS messages of type handshake, alert or change_cipher_spec are not allowed to be empty.