### PR TITLE
Modified setImmediate polyfill to fix IE/Edge bug

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -29,7 +29,7 @@ var util = forge.util = forge.util || {};
 
   // polyfill nextTick with native setImmediate
   if(typeof setImmediate === 'function') {
-    util.setImmediate = setImmediate;
+    util.setImmediate = function() { return setImmediate.apply(undefined, arguments); };
     util.nextTick = function(callback) {
       return setImmediate(callback);
     };


### PR DESCRIPTION
https://github.com/digitalbazaar/forge/issues/385
I tested this using the automated tests in node, Internet Explorer, Edge, Firefox, and Google Chrome. The automated tests did indeed fail in Edge and Internet Explorer on the master branch, but this commit fixes those tests with no regressions that I can see.