### PR TITLE
UTF8 decode pki.RDN attributes

### DIFF
--- a/js/x509.js
+++ b/js/x509.js
@@ -507,6 +507,9 @@ pki.RDNAttributesAsArray = function(rdn, md) {
       obj.type = asn1.derToOid(attr.value[0].value);
       obj.value = attr.value[1].value;
       obj.valueTagClass = attr.value[1].type;
+      if(obj.valueTagClass === asn1.Type.UTF8) {
+        obj.value = forge.util.decodeUtf8(obj.value);
+      }
       // if the OID is known, get its name and short name
       if(obj.type in oids) {
         obj.name = oids[obj.type];


### PR DESCRIPTION
When creating PKCS7 sign with certificate having DN with non-ascii characters, pkcs7 structure contains double encoded DN atributes (double UTF8 encoding)
