### PR TITLE
Bug fix invalid crl distribution points

### DIFF
--- a/js/x509.js
+++ b/js/x509.js
@@ -2312,8 +2312,11 @@ function _fillMissingExtensionFields(e, options) {
     e.value = asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, []);
     var seq = e.value.value;
 
-    // Create sub sequence distribution points
+    // Create sub SEQUENCE of DistributionPointName
     var subSeq = asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, []);
+
+    // Create fullName CHOICE
+    var fullNameGeneralNames = asn1.create(asn1.Class.CONTEXT_SPECIFIC, 0, true, []);
     var altName;
     for(var n = 0; n < e.altNames.length; ++n) {
       altName = e.altNames[n];
@@ -2336,11 +2339,13 @@ function _fillMissingExtensionFields(e, options) {
           value = asn1.oidToDer(value);
         }
       }
-      subSeq.value.push(asn1.create(
+      fullNameGeneralNames.value.push(asn1.create(
         asn1.Class.CONTEXT_SPECIFIC, altName.type, false,
         value));
     }
 
+    // Add to the parent SEQUENCE
+    subSeq.value.push(asn1.create(asn1.Class.CONTEXT_SPECIFIC, 0, true, [fullNameGeneralNames]));
     seq.push(subSeq);
   }
 

--- a/nodejs/test/x509.js
+++ b/nodejs/test/x509.js
@@ -317,9 +317,9 @@ function Tests(ASSERT, PKI, MD, UTIL) {
       var ext = cert.extensions[index];
       ASSERT.equal(ext.name, 'cRLDistributionPoints');
       ASSERT.equal(ext.value, UTIL.hexToBytes(
-        '30543052865068747470733a2f2f746573742d6f7267616e69736174696f6e2e63' +
-        '6f6d2f746573742d6f7267616e69736174696f6e2f63726c2f746573745f6f7267' +
-        '616e69736174696f6e5f63612e63726c2e646572'));
+        '30583056a054a052865068747470733a2f2f746573742d6f7267616e6973617469' +
+        '6f6e2e636f6d2f746573742d6f7267616e69736174696f6e2f63726c2f74657374' +
+        '5f6f7267616e69736174696f6e5f63612e63726c2e646572'));
 
       // verify certificate chain
       var caStore = PKI.createCaStore();


### PR DESCRIPTION
- This is a bug fix to wrap the CRL Dist points in CHOICE as given in [rfc5280](https://tools.ietf.org/html/rfc5280#section-4.2.1.13)
- Otherwise it would fail cert verification: `openssl verify -CAfile <ca> <cert>`