### PR TITLE
CA store updates

### DIFF
--- a/js/x509.js
+++ b/js/x509.js
@@ -2828,6 +2828,10 @@ pki.createCaStore = function(certs) {
    */
   caStore.removeCertificate = function(cert) {
     var result;
+    // convert from pem if necessary
+    if(typeof cert === 'string') {
+      cert = forge.pki.certificateFromPem(cert);
+    }
     assureSubjectHasHash(cert.subject);
     if (caStore.hasCertificate(cert)) {
       var match = getBySubject(cert.subject);

--- a/js/x509.js
+++ b/js/x509.js
@@ -2745,34 +2745,37 @@ pki.createCaStore = function(certs) {
       cert = forge.pki.certificateFromPem(cert);
     }
 
-    // produce subject hash if it doesn't exist
-    if(!cert.subject.hash) {
-      var md = forge.md.sha1.create();
-      cert.subject.attributes =  pki.RDNAttributesAsArray(
-        _dnToAsn1(cert.subject), md);
-      cert.subject.hash = md.digest().toHex();
-    }
+    assureSubjectHasHash(cert.subject);
 
-    if(cert.subject.hash in caStore.certs) {
-      // subject hash already exists, append to array
-      var tmp = caStore.certs[cert.subject.hash];
-      if(!forge.util.isArray(tmp)) {
-        tmp = [tmp];
+    if (!caStore.hasCertificate(cert)) {  // avoid duplicate certificates in store
+      if(cert.subject.hash in caStore.certs) {
+        // subject hash already exists, append to array
+        var tmp = caStore.certs[cert.subject.hash];
+        if(!forge.util.isArray(tmp)) {
+          tmp = [tmp];
+        }
+        tmp.push(cert);
+        caStore.certs[cert.subject.hash] = tmp;
+      } else {
+        caStore.certs[cert.subject.hash] = cert;
       }
-      tmp.push(cert);
-    } else {
-      caStore.certs[cert.subject.hash] = cert;
     }
   };
 
   /**
    * Checks to see if the given certificate is in the store.
    *
-   * @param cert the certificate to check.
+   * @param cert the certificate to check (either a pki.certificate or a PEM-formatted
+   *          certificate).
    *
    * @return true if the certificate is in the store, false if not.
    */
   caStore.hasCertificate = function(cert) {
+    // convert from pem if necessary
+    if(typeof cert === 'string') {
+      cert = forge.pki.certificateFromPem(cert);
+    }
+
     var match = getBySubject(cert.subject);
     if(!match) {
       return false;
@@ -2791,14 +2794,80 @@ pki.createCaStore = function(certs) {
     return false;
   };
 
+  /**
+   * Lists all of the forge certificates kept in the store.
+   *
+   * @returns Array of all of the pki.certificate objects in the store.
+   */
+  caStore.listAllCertificates = function() {
+    var certList = [];
+
+    for (var hash in caStore.certs) {
+      if (caStore.certs.hasOwnProperty(hash)) {
+        var value = caStore.certs[hash];
+        if (!forge.util.isArray(value)) {
+          certList.push(value);
+        } else {
+          for (var i = 0; i < value.length; i++) {
+            certList.push(value[i]);
+          }
+        }
+      }
+    }
+
+    return certList;
+  };
+
+  /**
+   * Removes a certificate from the store.
+   *
+   * @param cert - the certificate to remove (either a pki.certificate or a PEM-formatted
+   *          certificate).
+   *
+   * @returns the certificate that was removed or null if the certificate wasn't in store.
+   */
+  caStore.removeCertificate = function(cert) {
+    var result;
+    assureSubjectHasHash(cert.subject);
+    if (caStore.hasCertificate(cert)) {
+      var match = getBySubject(cert.subject);
+
+      if (!forge.util.isArray(match)) {
+        result = caStore.certs[cert.subject.hash];
+        delete caStore.certs[cert.subject.hash];
+      } else {
+        // compare DER-encoding of certificates
+        var der1 = asn1.toDer(pki.certificateToAsn1(cert)).getBytes();
+        for(var i = 0; i < match.length; ++i) {
+          var der2 = asn1.toDer(pki.certificateToAsn1(match[i])).getBytes();
+          if(der1 === der2) {
+            result = match[i];
+            match.splice(i, 1);
+          }
+        }
+        if (match.length === 0) {
+          delete caStore.certs[cert.subject.hash];
+        }
+      }
+    } else {
+      result = null;
+    }
+
+    return result;
+  };
+
   function getBySubject(subject) {
+    assureSubjectHasHash(subject);
+    return caStore.certs[subject.hash] || null;
+  }
+
+  function assureSubjectHasHash(subject) {
     // produce subject hash if it doesn't exist
     if(!subject.hash) {
       var md = forge.md.sha1.create();
       subject.attributes =  pki.RDNAttributesAsArray(_dnToAsn1(subject), md);
       subject.hash = md.digest().toHex();
     }
-    return caStore.certs[subject.hash] || null;
   }
 
   // auto-add passed in certs

--- a/tests/nodejs-castore.js
+++ b/tests/nodejs-castore.js
@@ -1,0 +1,175 @@
+var forge = require('../js/forge');
+
+var keyPair1 = forge.pki.rsa.generateKeyPair(1024);
+var keyPair2 = forge.pki.rsa.generateKeyPair(1024);
+var keyPair3 = forge.pki.rsa.generateKeyPair(2048);
+
+var ca1 = forge.pki.createCertificate();
+var ca2 = forge.pki.createCertificate();
+var ca3 = forge.pki.createCertificate();
+
+
+ca1.publicKey = keyPair1.publicKey;
+ca2.publicKey = keyPair2.publicKey;
+ca3.publicKey = keyPair3.publicKey;
+
+ca1.serialNumber = "01";
+ca2.serialNumber = "02";
+ca3.serialNumber = "03";
+
+ca1.validity.notBefore = new Date();
+ca2.validity.notBefore = new Date();
+ca3.validity.notBefore = new Date();
+
+ca1.validity.notAfter = new Date();
+ca1.validity.notAfter.setFullYear(ca1.validity.notBefore.getFullYear() + 1);
+ca2.validity.notAfter = new Date();
+ca2.validity.notAfter.setFullYear(ca2.validity.notBefore.getFullYear() + 2);
+ca3.validity.notAfter = new Date();
+ca3.validity.notAfter.setFullYear(ca3.validity.notBefore.getFullYear() + 3);
+
+var attrs = [
+  {
+    name: 'commonName',
+    value: 'Cert Authority'
+  }
+];
+
+var attrs3 = [
+  {
+    name: 'commonName',
+    value: "Other Cert Authority"
+  },
+  {
+    name: 'countryName',
+    value: 'CO'
+  },
+  {
+    shortName: 'ST',
+    value: "Antioquia"
+  },
+  {
+    shortName: "L",
+    value: "Medellin"
+  }
+];
+
+// note that both CAs 1 and 2 have the same subject distinguished name
+ca1.setSubject(attrs);
+ca2.setSubject(attrs);
+
+ca3.setSubject(attrs3);
+
+
+ca1.setExtensions([
+  {
+    name: 'basicConstraints',
+    cA: true,
+    pathLenConstraint: 4
+  }, {
+    name: 'keyUsage',
+    keyCertSign: true,
+    digitalSignature: true,
+    nonRepudiation: true,
+    keyEncipherment: true,
+    dataEncipherment: true
+  }
+]);
+
+ca2.setExtensions([
+  {
+    name: 'basicConstraints',
+    cA: true,
+    pathLenConstraint: 2
+  }, {
+    name: 'keyUsage',
+    keyCertSign: true,
+    digitalSignature: true
+  }
+]);
+
+ca1.setExtensions([
+  {
+    name: 'basicConstraints',
+    cA: true
+  }, {
+    name: 'keyUsage',
+    keyCertSign: true,
+    digitalSignature: true,
+    nonRepudiation: true,
+  }
+]);
+
+ca1.sign(keyPair1.privateKey);
+ca2.sign(keyPair2.privateKey);
+ca3.sign(keyPair3.privateKey);
+
+var caStore = forge.pki.createCaStore();
+
+caStore.addCertificate(ca1);
+console.log("added ca1 to caStore");
+caStore.addCertificate(ca2);
+console.log("added ca2 to caStore");
+
+console.log("caStore has ca1:", caStore.hasCertificate(ca1));
+console.log("caStore has ca2:", caStore.hasCertificate(ca2));
+console.log("caStore has ca3:", caStore.hasCertificate(ca3));
+console.log("number of certs in caStore:", caStore.listAllCertificates().length);
+
+caStore.addCertificate(ca3);
+console.log("added ca3 to caStore");
+
+console.log("caStore has ca1:", caStore.hasCertificate(ca1));
+console.log("caStore has ca2:", caStore.hasCertificate(ca2));
+console.log("caStore has ca3:", caStore.hasCertificate(ca3));
+console.log("number of certs in caStore:", caStore.listAllCertificates().length);
+
+caStore.removeCertificate(ca2);
+console.log("removed ca2 from caStore");
+
+console.log("caStore has ca1:", caStore.hasCertificate(ca1));
+console.log("caStore has ca2:", caStore.hasCertificate(ca2));
+console.log("caStore has ca3:", caStore.hasCertificate(ca3));
+console.log("number of certs in caStore:", caStore.listAllCertificates().length);
+
+caStore.removeCertificate(ca1);
+console.log("removed ca1 from caStore");
+
+console.log("caStore has ca1:", caStore.hasCertificate(ca1));
+console.log("caStore has ca2:", caStore.hasCertificate(ca2));
+console.log("caStore has ca3:", caStore.hasCertificate(ca3));
+console.log("number of certs in caStore:", caStore.listAllCertificates().length);
+
+caStore.addCertificate(ca3);
+console.log("tried to add ca3 to store even though its already there");
+
+console.log("caStore has ca1, using PEM cert string:",
+            caStore.hasCertificate(forge.pki.certificateToPem(ca1)));
+console.log("caStore has ca2, using PEM cert string:",
+            caStore.hasCertificate(forge.pki.certificateToPem(ca2)));
+console.log("caStore has ca3, using PEM cert string:",
+            caStore.hasCertificate(forge.pki.certificateToPem(ca3)));
+console.log("number of certs in caStore:", caStore.listAllCertificates().length);
+
+
+console.log("tried to remove ca1 from caStore even though its not there, result:",
+            caStore.removeCertificate(ca1));
+
+caStore.addCertificate(forge.pki.certificateToPem(ca2));
+console.log("added ca2 to caStore as PEM string");
+
+console.log("caStore has ca1:", caStore.hasCertificate(ca1));
+console.log("caStore has ca2:", caStore.hasCertificate(ca2));
+console.log("caStore has ca3:", caStore.hasCertificate(ca3));
+console.log("number of certs in caStore:", caStore.listAllCertificates().length);
+
+caStore.removeCertificate(forge.pki.certificateToPem(ca3));
+console.log("removed ca3 from caStore as a PEM string");
+
+console.log("caStore has ca1:", caStore.hasCertificate(ca1));
+console.log("caStore has ca2:", caStore.hasCertificate(ca2));
+console.log("caStore has ca3:", caStore.hasCertificate(ca3));
+console.log("number of certs in caStore:", caStore.listAllCertificates().length);
+
+console.log("In the end, the caStore should just have one certificate: ca2");
+


### PR DESCRIPTION
I wrote these updates to the caStore to achieve several goals:

- Fix the bug I already outlined in issue #420 
- Make the methods of the caStore more consistent in the types of certificates they accept. Specifically, the addCertificate method accepts a pki.certficate object or a PEM string, but the hasCertificate method only accepts a pki.certificate. My pull request, gives all methods of caStore that accept a certificate as a parameter the ability to receive either a pki.certificate or a PEM string, including the added methods (see below).
- Add a listAllCertificates method, which allows a caStore to be serialized for storage in a database or for sending across a network and then restored at a later time.
- Add a removeCertificate method
- Add testing for this new functionality in the form of the tests/nodejs-castore.js file

 