### PR TITLE
Remove dependency from jQuery for modules random and util

### DIFF
--- a/js/random.js
+++ b/js/random.js
@@ -22,7 +22,7 @@ if(forge.random && forge.random.getBytes) {
   return;
 }
 
-(function(jQuery) {
+(function(global) {
 
 // the default prng plugin, uses AES-128
 var prng_aes = {};
@@ -151,20 +151,21 @@ if(forge.disableNativeCode || (!_nodejs && !getRandomValues)) {
     _navBytes = null;
   }
 
-  // add mouse and keyboard collectors if jquery is available
-  if(jQuery) {
+  // if we are in the browser, use keyboard and mouse to gather entropy
+  if (global.document && global.document.addEventListener) {
     // set up mouse entropy capture
-    jQuery().mousemove(function(e) {
+    document.addEventListener('mousemove', function(e) {
       // add mouse coords
       _ctx.collectInt(e.clientX, 16);
       _ctx.collectInt(e.clientY, 16);
-    });
+    }, false);
 
     // set up keyboard entropy capture
-    jQuery().keypress(function(e) {
+    document.addEventListener('keypress', function(e) {
       _ctx.collectInt(e.charCode, 8);
-    });
+    }, false);
   }
+
 }
 
 /* Random API */
@@ -180,7 +181,7 @@ if(!forge.random) {
 // expose spawn PRNG
 forge.random.createInstance = spawnPrng;
 
-})(typeof(jQuery) !== 'undefined' ? jQuery : null);
+})((0, eval)('this'));
 
 } // end module implementation
 

--- a/js/random.js
+++ b/js/random.js
@@ -22,7 +22,9 @@ if(forge.random && forge.random.getBytes) {
   return;
 }
 
-(function(global) {
+var jQuery = (function(g) { return g.jQuery; })((0, eval)('this'));
+
+(function(jQuery) {
 
 // the default prng plugin, uses AES-128
 var prng_aes = {};
@@ -151,21 +153,20 @@ if(forge.disableNativeCode || (!_nodejs && !getRandomValues)) {
     _navBytes = null;
   }
 
-  // if we are in the browser, use keyboard and mouse to gather entropy
-  if (global.document && global.document.addEventListener) {
+  // add mouse and keyboard collectors if jquery is available
+  if(jQuery) {
     // set up mouse entropy capture
-    document.addEventListener('mousemove', function(e) {
+    jQuery().mousemove(function(e) {
       // add mouse coords
       _ctx.collectInt(e.clientX, 16);
       _ctx.collectInt(e.clientY, 16);
-    }, false);
+    });
 
     // set up keyboard entropy capture
-    document.addEventListener('keypress', function(e) {
+    jQuery().keypress(function(e) {
       _ctx.collectInt(e.charCode, 8);
-    }, false);
+    });
   }
-
 }
 
 /* Random API */
@@ -181,7 +182,7 @@ if(!forge.random) {
 // expose spawn PRNG
 forge.random.createInstance = spawnPrng;
 
-})((0, eval)('this'));
+})(typeof(jQuery) !== 'undefined' ? jQuery : null);
 
 } // end module implementation
 

--- a/js/util.js
+++ b/js/util.js
@@ -2426,28 +2426,6 @@ util.makeRequest = function(reqString) {
 };
 
 /**
- * Makes a URI out of a path, an object with query parameters, and a
- * fragment. Uses jQuery.param() internally for query string creation.
- * If the path is an array, it will be joined with '/'.
- *
- * @param path string path or array of strings.
- * @param query object with query parameters. (optional)
- * @param fragment fragment string. (optional)
- *
- * @return string object with request parameters.
- */
-util.makeLink = function(path, query, fragment) {
-  // join path parts if needed
-  path = jQuery.isArray(path) ? path.join('/') : path;
-
-  var qstr = jQuery.param(query || {});
-  fragment = fragment || '';
-  return path +
-    ((qstr.length > 0) ? ('?' + qstr) : '') +
-    ((fragment.length > 0) ? ('#' + fragment) : '');
-};
-
-/**
  * Follows a path of keys deep into an object hierarchy and set a value.
  * If a key does not exist or it's value is not an object, create an
  * object in it's place. This can be destructive to a object tree if

--- a/js/util.js
+++ b/js/util.js
@@ -12,6 +12,8 @@ function initModule(forge) {
 /* Utilities API */
 var util = forge.util = forge.util || {};
 
+var jQuery = (function(g) { return g.jQuery; })((0, eval)('this'));
+
 // define setImmediate and nextTick
 (function() {
   // use native nextTick
@@ -2423,6 +2425,28 @@ util.makeRequest = function(reqString) {
     }
   };
   return req;
+};
+
+/**
+ * Makes a URI out of a path, an object with query parameters, and a
+ * fragment. Uses jQuery.param() internally for query string creation.
+ * If the path is an array, it will be joined with '/'.
+ *
+ * @param path string path or array of strings.
+ * @param query object with query parameters. (optional)
+ * @param fragment fragment string. (optional)
+ *
+ * @return string object with request parameters.
+ */
+util.makeLink = function(path, query, fragment) {
+  // join path parts if needed
+  path = jQuery.isArray(path) ? path.join('/') : path;
+
+  var qstr = jQuery.param(query || {});
+  fragment = fragment || '';
+  return path +
+    ((qstr.length > 0) ? ('?' + qstr) : '') +
+    ((fragment.length > 0) ? ('#' + fragment) : '');
 };
 
 /**


### PR DESCRIPTION
Hi,
This pull request removes the "dependency" from jQuery for modules `random` and `util`.
Although jQuery is not an actual dependency, the presence of the unbound identifier `jQuery` in the code may confuse some bundlers like WebPack to think that Forge depends on jQuery, causing some troubles if Forge is used in a context where jQuery can't be loaded, such as a WebWorker.

I reworked only the modules `random` and `util` since they are the only ones referencing jQuery included in the default bundle.

Also, I completely removed the function `util.makeLink` since it appears to be dead code. All the tests pass, so _maybe_ it's safe to remove.
