### PR TITLE
Fix issue with generation of bundled and minified forge file on Windows.

### DIFF
--- a/optimize.js
+++ b/optimize.js
@@ -1,0 +1,20 @@
+/**
+ * Prepares bundle for Node Forge Library based on OS platform.
+ */
+const os = require('os');
+const exec = require('child_process').exec;
+
+/**
+ * Remove first two arguments in the array which represent execution path and file path.
+ * https://nodejs.org/docs/latest/api/process.html#process_process_argv
+ *
+ * @type {Array.<string>} Command line arguments
+ */
+var commandLineArgs = process.argv.slice(2);
+
+//If OS is windows, use `r.js.cmd` to run the optimization. In other OS, use `r.js` command.
+if (os.platform() === 'win32') {
+  exec('r.js.cmd ' + commandLineArgs.join(' '));
+} else {
+  exec('r.js ' + commandLineArgs.join(' '));
+}

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "x509"
   ],
   "scripts": {
-    "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
-    "minify": "r.js -o minify.js",
+    "bundle": "node optimize.js -o minify.js optimize=none out=js/forge.bundle.js",
+    "minify": "node optimize.js -o minify.js",
     "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
     "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
   },


### PR DESCRIPTION
* Use `r.js.cmd` to generate optimized resources when running on Windows.
* Create new file `optimize.js` which determines the OS platform and runs the correct command to perform optimization.