### PR TITLE
create password buffer with encoding binary

### DIFF
--- a/lib/pbkdf2.js
+++ b/lib/pbkdf2.js
@@ -51,6 +51,7 @@ module.exports = forge.pbkdf2 = pkcs5.pbkdf2 = function(
       // default prf to SHA-1
       md = 'sha1';
     }
+    p = new Buffer(p, 'binary');
     s = new Buffer(s, 'binary');
     if(!callback) {
       if(crypto.pbkdf2Sync.length === 4) {

--- a/tests/unit/pbkdf2.js
+++ b/tests/unit/pbkdf2.js
@@ -22,6 +22,11 @@ var UTIL = require('../../lib/util');
       ASSERT.equal(dkHex, 'd1daa78615f287e6');
     });
 
+    it('should derive a utf8 password with hmac-sha-1 c=1 keylen=16', function() {
+      var dkHex = UTIL.bytesToHex(PBKDF2('中', 'salt', 1, 16));
+      ASSERT.equal(dkHex, '5f719aa196edc4df6b1556de503faaf3');
+    });
+
     it('should derive a password with hmac-sha-1 c=4096', function() {
       // Note: might be too slow on old browsers
       var dkHex = UTIL.bytesToHex(PBKDF2('password', 'salt', 4096, 20));


### PR DESCRIPTION
> The default encoding for all crypto methods is utf8.

refer: [Breaking changes between v5 and v6](https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6)
