### PR TITLE
Fix parsing content of PKCS#7-message if it is DER-data

### DIFF
--- a/lib/pkcs7.js
+++ b/lib/pkcs7.js
@@ -1183,6 +1183,8 @@ function _fromAsn1(msg, obj, validator) {
         }
         content += capture.content[i].value;
       }
+    } else if (typeof capture.content === 'object') {
+      content = asn1.toDer(capture.content).getBytes();
     } else {
       content = capture.content;
     }


### PR DESCRIPTION
If i use DER-data as a "content" of PKCS#7 message then after i parse it from PEM-format i get the ByteString with zero length instead of valid DER-bytes. This commit fixes that problem.