### PR TITLE
set correct digest size for hashes based on SHA-512

### DIFF
--- a/lib/sha512.js
+++ b/lib/sha512.js
@@ -79,12 +79,26 @@ sha512.create = function(algorithm) {
     _w[wi] = new Array(2);
   }
 
+  // determine digest length by algorithm name (default)
+  var digestLength = 64;
+  switch (algorithm) {
+    case 'SHA-384':
+      digestLength = 48;
+      break;
+    case 'SHA-512/256':
+      digestLength = 32;
+      break;
+    case 'SHA-512/224':
+      digestLength = 28;
+      break;
+  }
+
   // message digest object
   var md = {
     // SHA-512 => sha512
     algorithm: algorithm.replace('-', '').toLowerCase(),
     blockLength: 128,
-    digestLength: 64,
+    digestLength: digestLength,
     // 56-bit length of message so far (does not including padding)
     messageLength: 0,
     // true message length


### PR DESCRIPTION
Without this change, PSS (using something other than sha1 / sha256 / sha512) could be incorrectly calculated, thereby throwing a `index out of range` error.