### PR TITLE
Add optional date parameter to pki.verifyCertificateChain

### DIFF
--- a/lib/x509.js
+++ b/lib/x509.js
@@ -2899,6 +2899,7 @@ pki.certificateError = {
  * @param chain the certificate chain to verify, with the root or highest
  *          authority at the end (an array of certificates).
  * @param verify called for every certificate in the chain.
+ * @param date optional date to check for validity. Defaults to current date.
  *
  * The verify callback has the following signature:
  *
@@ -2914,7 +2915,7 @@ pki.certificateError = {
  *
  * @return true if successful, error thrown if not.
  */
-pki.verifyCertificateChain = function(caStore, chain, verify) {
+pki.verifyCertificateChain = function(caStore, chain, verify, date) {
   /* From: RFC3280 - Internet X.509 Public Key Infrastructure Certificate
     Section 6: Certification Path Validation
     See inline parentheticals related to this particular implementation.
@@ -3050,7 +3051,7 @@ pki.verifyCertificateChain = function(caStore, chain, verify) {
   var certs = chain.slice(0);
 
   // get current date
-  var now = new Date();
+  var signDate = date || new Date();
 
   // verify each cert in the chain using its parent, where the parent
   // is either the next in the chain or from the CA store
@@ -3063,13 +3064,13 @@ pki.verifyCertificateChain = function(caStore, chain, verify) {
     var selfSigned = false;
 
     // 1. check valid time
-    if(now < cert.validity.notBefore || now > cert.validity.notAfter) {
+    if(signDate < cert.validity.notBefore || signDate > cert.validity.notAfter) {
       error = {
         message: 'Certificate is not valid yet or has expired.',
         error: pki.certificateError.certificate_expired,
         notBefore: cert.validity.notBefore,
         notAfter: cert.validity.notAfter,
-        now: now
+        now: signDate
       };
     }
 


### PR DESCRIPTION
Add an optional date to pki.verifyCertificateChain to check for validity on a specific date. This was included in the old 0.7.x branch which is now called 0.8.x.