### PR TITLE
Fix issue where encrypted data was not decryptable

### DIFF
--- a/lib/pkcs1.js
+++ b/lib/pkcs1.js
@@ -142,7 +142,7 @@ pkcs1.encode_rsa_oaep = function(key, message, options) {
   var maskedSeed = forge.util.xorBytes(seed, seedMask, seed.length);
 
   // return encoded message
-  return '\x00' + maskedSeed + maskedDB;
+  return maskedSeed + maskedDB;
 };
 
 /**


### PR DESCRIPTION
We are encrypting on the front end using RSA-OAEP. 

    const encrypted = key.encrypt(data, 'RSA-OAEP', {
      md: Forge.md.sha256.create(),
      mgf1: {
        md: Forge.md.sha256.create()
      }
    });

We found that we were not able to decrypt with either bouncy castle or the HSM. 

After debugging with forge and bouncy castle side by side we found this was the only difference between the libraries.
