### PR TITLE
TLS 1.2 implementation

### DIFF
--- a/lib/aesCipherSuites.js
+++ b/lib/aesCipherSuites.js
@@ -47,6 +47,43 @@ tls.CipherSuites['TLS_RSA_WITH_AES_256_CBC_SHA'] = {
   },
   initConnectionState: initConnectionState
 };
+// TLS 1.2
+tls.CipherSuites['TLS_RSA_WITH_AES_128_CBC_SHA256'] = {
+  id: [0x00,0x3c],
+  name: 'TLS_RSA_WITH_AES_128_CBC_SHA256',
+  initSecurityParameters: function(sp) {
+      console.log('----- AES128 initSecurityParameters()')
+    sp.bulk_cipher_algorithm = tls.BulkCipherAlgorithm.aes;
+    sp.cipher_type = tls.CipherType.block;
+    sp.enc_key_length = 16;
+    sp.block_length = 16;
+    sp.fixed_iv_length = 16;
+    sp.record_iv_length = 16;
+    sp.mac_algorithm = tls.MACAlgorithm.hmac_sha256;
+    sp.mac_length = 32;
+    sp.mac_key_length = 32;
+  },
+  initConnectionState: initConnectionState
+};
+// TLS 1.2
+tls.CipherSuites['TLS_RSA_WITH_AES_256_CBC_SHA256'] = {
+  id: [0x00,0x3d],
+  name: 'TLS_RSA_WITH_AES_256_CBC_SHA256',
+  initSecurityParameters: function(sp) {
+      console.log('----- AES256 initSecurityParameters()')
+    sp.bulk_cipher_algorithm = tls.BulkCipherAlgorithm.aes;
+    sp.cipher_type = tls.CipherType.block;
+    sp.enc_key_length = 32;
+    sp.block_length = 16;
+    sp.fixed_iv_length = 16;
+    sp.record_iv_length = 16;
+    sp.mac_algorithm = tls.MACAlgorithm.hmac_sha256;
+    sp.mac_length = 32;
+    sp.mac_key_length = 32;
+  },
+  initConnectionState: initConnectionState
+};
+
 
 function initConnectionState(state, c, sp) {
   var client = (c.entity === forge.tls.ConnectionEnd.client);
@@ -69,7 +106,16 @@ function initConnectionState(state, c, sp) {
 
   // MAC setup
   state.read.macLength = state.write.macLength = sp.mac_length;
-  state.read.macFunction = state.write.macFunction = tls.hmac_sha1;
+  switch(sp.mac_algorithm) {
+      case tls.MACAlgorithm.hmac_sha256:
+        state.read.macFunction = state.write.macFunction = tls.hmac_sha256;
+        break;
+      case tls.MACAlgorithm.hmac_sha1:
+        state.read.macFunction = state.write.macFunction = tls.hmac_sha1;
+        break;
+      default:
+        throw new Exception('Unknown HMAC function');
+  }
 }
 
 /**

--- a/lib/aesCipherSuites.js
+++ b/lib/aesCipherSuites.js
@@ -15,38 +15,6 @@ var tls = module.exports = forge.tls;
 /**
  * Supported cipher suites.
  */
-tls.CipherSuites['TLS_RSA_WITH_AES_128_CBC_SHA'] = {
-  id: [0x00,0x2f],
-  name: 'TLS_RSA_WITH_AES_128_CBC_SHA',
-  initSecurityParameters: function(sp) {
-    sp.bulk_cipher_algorithm = tls.BulkCipherAlgorithm.aes;
-    sp.cipher_type = tls.CipherType.block;
-    sp.enc_key_length = 16;
-    sp.block_length = 16;
-    sp.fixed_iv_length = 16;
-    sp.record_iv_length = 16;
-    sp.mac_algorithm = tls.MACAlgorithm.hmac_sha1;
-    sp.mac_length = 20;
-    sp.mac_key_length = 20;
-  },
-  initConnectionState: initConnectionState
-};
-tls.CipherSuites['TLS_RSA_WITH_AES_256_CBC_SHA'] = {
-  id: [0x00,0x35],
-  name: 'TLS_RSA_WITH_AES_256_CBC_SHA',
-  initSecurityParameters: function(sp) {
-    sp.bulk_cipher_algorithm = tls.BulkCipherAlgorithm.aes;
-    sp.cipher_type = tls.CipherType.block;
-    sp.enc_key_length = 32;
-    sp.block_length = 16;
-    sp.fixed_iv_length = 16;
-    sp.record_iv_length = 16;
-    sp.mac_algorithm = tls.MACAlgorithm.hmac_sha1;
-    sp.mac_length = 20;
-    sp.mac_key_length = 20;
-  },
-  initConnectionState: initConnectionState
-};
 // TLS 1.2
 tls.CipherSuites['TLS_RSA_WITH_AES_128_CBC_SHA256'] = {
   id: [0x00,0x3c],
@@ -80,6 +48,39 @@ tls.CipherSuites['TLS_RSA_WITH_AES_256_CBC_SHA256'] = {
     sp.mac_algorithm = tls.MACAlgorithm.hmac_sha256;
     sp.mac_length = 32;
     sp.mac_key_length = 32;
+  },
+  initConnectionState: initConnectionState
+};
+
+tls.CipherSuites['TLS_RSA_WITH_AES_128_CBC_SHA'] = {
+  id: [0x00,0x2f],
+  name: 'TLS_RSA_WITH_AES_128_CBC_SHA',
+  initSecurityParameters: function(sp) {
+    sp.bulk_cipher_algorithm = tls.BulkCipherAlgorithm.aes;
+    sp.cipher_type = tls.CipherType.block;
+    sp.enc_key_length = 16;
+    sp.block_length = 16;
+    sp.fixed_iv_length = 16;
+    sp.record_iv_length = 16;
+    sp.mac_algorithm = tls.MACAlgorithm.hmac_sha1;
+    sp.mac_length = 20;
+    sp.mac_key_length = 20;
+  },
+  initConnectionState: initConnectionState
+};
+tls.CipherSuites['TLS_RSA_WITH_AES_256_CBC_SHA'] = {
+  id: [0x00,0x35],
+  name: 'TLS_RSA_WITH_AES_256_CBC_SHA',
+  initSecurityParameters: function(sp) {
+    sp.bulk_cipher_algorithm = tls.BulkCipherAlgorithm.aes;
+    sp.cipher_type = tls.CipherType.block;
+    sp.enc_key_length = 32;
+    sp.block_length = 16;
+    sp.fixed_iv_length = 16;
+    sp.record_iv_length = 16;
+    sp.mac_algorithm = tls.MACAlgorithm.hmac_sha1;
+    sp.mac_length = 20;
+    sp.mac_key_length = 20;
   },
   initConnectionState: initConnectionState
 };

--- a/lib/prng.js
+++ b/lib/prng.js
@@ -48,7 +48,9 @@ prng.create = function(plugin) {
     // number of reseeds so far
     reseeds: 0,
     // amount of data generated so far
-    generated: 0
+    generated: 0,
+    // no initial key bytes
+    keyBytes: ''
   };
 
   // create 32 entropy pools (each is a message digest)
@@ -205,35 +207,40 @@ prng.create = function(plugin) {
    * Private function that seeds a generator once enough bytes are available.
    */
   function _seed() {
+    // update reseed count
+    ctx.reseeds = (ctx.reseeds === 0xffffffff) ? 0 : ctx.reseeds + 1;
+
+    // goal is to update `key` and `seed` via:
+    // key = hash(key + s)
+    //   where 's' is all collected entropy from selected pools, then...
+    // seed = hash(key)
+
     // create a plugin-based message digest
     var md = ctx.plugin.md.create();
 
-    // digest pool 0's entropy and restart it
-    md.update(ctx.pools[0].digest().getBytes());
-    ctx.pools[0].start();
+    // consume current key bytes
+    md.update(ctx.keyBytes);
 
-    // digest the entropy of other pools whose index k meet the
-    // condition '2^k mod n == 0' where n is the number of reseeds
-    var k = 1;
-    for(var i = 1; i < 32; ++i) {
-      // prevent signed numbers from being used
-      k = (k === 31) ? 0x80000000 : (k << 2);
-      if(k % ctx.reseeds === 0) {
-        md.update(ctx.pools[i].digest().getBytes());
-        ctx.pools[i].start();
+    // digest the entropy of pools whose index k meet the
+    // condition 'n mod 2^k == 0' where n is the number of reseeds
+    var _2powK = 1;
+    for(var k = 0; k < 32; ++k) {
+      if(ctx.reseeds % _2powK === 0) {
+        md.update(ctx.pools[k].digest().getBytes());
+        ctx.pools[k].start();
       }
+      _2powK = _2powK << 1;
     }
 
     // get digest for key bytes and iterate again for seed bytes
-    var keyBytes = md.digest().getBytes();
+    ctx.keyBytes = md.digest().getBytes();
     md.start();
-    md.update(keyBytes);
+    md.update(ctx.keyBytes);
     var seedBytes = md.digest().getBytes();
 
-    // update
-    ctx.key = ctx.plugin.formatKey(keyBytes);
+    // update state
+    ctx.key = ctx.plugin.formatKey(ctx.keyBytes);
     ctx.seed = ctx.plugin.formatSeed(seedBytes);
-    ctx.reseeds = (ctx.reseeds === 0xffffffff) ? 0 : ctx.reseeds + 1;
     ctx.generated = 0;
   }
 

--- a/lib/prng.js
+++ b/lib/prng.js
@@ -87,7 +87,11 @@ prng.create = function(plugin) {
     var formatSeed = ctx.plugin.formatSeed;
     var b = forge.util.createBuffer();
 
-    // reset key for every request
+    // paranoid deviation from Fortuna:
+    // reset key for every request to protect previously
+    // generated random bytes should the key be discovered;
+    // there is no 100ms based reseeding because of this
+    // forced reseed for every `generate` call
     ctx.key = null;
 
     generate();
@@ -141,7 +145,11 @@ prng.create = function(plugin) {
     var formatKey = ctx.plugin.formatKey;
     var formatSeed = ctx.plugin.formatSeed;
 
-    // reset key for every request
+    // paranoid deviation from Fortuna:
+    // reset key for every request to protect previously
+    // generated random bytes should the key be discovered;
+    // there is no 100ms based reseeding because of this
+    // forced reseed for every `generateSync` call
     ctx.key = null;
 
     var b = forge.util.createBuffer();
@@ -210,10 +218,9 @@ prng.create = function(plugin) {
     // update reseed count
     ctx.reseeds = (ctx.reseeds === 0xffffffff) ? 0 : ctx.reseeds + 1;
 
-    // goal is to update `key` and `seed` via:
+    // goal is to update `key` via:
     // key = hash(key + s)
     //   where 's' is all collected entropy from selected pools, then...
-    // seed = hash(key)
 
     // create a plugin-based message digest
     var md = ctx.plugin.md.create();
@@ -232,8 +239,13 @@ prng.create = function(plugin) {
       _2powK = _2powK << 1;
     }
 
-    // get digest for key bytes and iterate again for seed bytes
+    // get digest for key bytes
     ctx.keyBytes = md.digest().getBytes();
+
+    // paranoid deviation from Fortuna:
+    // update `seed` via `seed = hash(key)`
+    // instead of initializing to zero once and only
+    // ever incrementing it
     md.start();
     md.update(ctx.keyBytes);
     var seedBytes = md.digest().getBytes();

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -358,20 +358,20 @@ var prf_TLS1 = function(secret, label, seed, length) {
  *
  * @return the pseudo random bytes in a byte buffer.
  */
-var prf_sha256 = function(secret, label, seed, length) {
+var prf_TLS12 = function(secret, label, seed, length, hashType) {
    var rval = forge.util.createBuffer();
 
    var ai = forge.util.createBuffer();
-   var sha256bytes = forge.util.createBuffer();
+   var shaBytes = forge.util.createBuffer();
    var hmac = forge.hmac.create();
    seed = label + seed;
 
-   var sha256itr = Math.ceil(length / 32);
+   var shaItr = Math.ceil(length / 32);
 
-   hmac.start('SHA256', secret);
+   hmac.start(hashType, secret);
    ai.clear();
    ai.putBytes(seed);
-   for(var i = 0; i < sha256itr; ++i) {
+   for(var i = 0; i < shaItr; ++i) {
      // HMAC_hash(secret, A(i-1))
      hmac.start(null, null);
      hmac.update(ai.getBytes());
@@ -380,11 +380,15 @@ var prf_sha256 = function(secret, label, seed, length) {
      // HMAC_hash(secret, A(i) + seed)
      hmac.start(null, null);
      hmac.update(ai.bytes() + seed);
-     sha256bytes.putBuffer(hmac.digest());
+     shaBytes.putBuffer(hmac.digest());
    }
-   rval.putBytes(sha256bytes.getBytes(length));
+   rval.putBytes(shaBytes.getBytes(length));
 
    return rval;
+};
+
+var prf_TLS12_sha256 = function(secret, label, seed, length) {
+    return prf_TLS12(secret, label, seed, length, "SHA256");
 };
 
 /**
@@ -1052,7 +1056,6 @@ tls.handleServerHello = function(c, record, length) {
 
   // indicate session version has been set
   c.session.version = c.version;
-
   // get the session ID from the message
   var sessionId = msg.session_id.bytes();
 
@@ -1865,20 +1868,19 @@ tls.handleFinished = function(c, record, length) {
   // ensure verify data is correct
   b = forge.util.createBuffer();
   if(tls12) {
-    prf = prf_sha256;
+    // TODO: Add support for SHA224 and SHA512.
+    prf = prf_TLS12_sha256;
     switch(c.session.sp.mac_algorithm) {
       case tls.MACAlgorithm.hmac_sha256:
-        b.putBuffer(c.session.sha256.digest());
-        break;
       case tls.MACAlgorithm.hmac_sha1:
-        b.putBuffer(c.session.sha1.digest());
+        b.putBuffer(c.session.sha256.digest());
         break;
       default:
         throw new Exception('Bad MACAlgorithm');
     }
   } else {
-  b.putBuffer(c.session.md5.digest());
-  b.putBuffer(c.session.sha1.digest());
+    b.putBuffer(c.session.md5.digest());
+    b.putBuffer(c.session.sha1.digest());
   }
 
   // set label based on entity type
@@ -2430,7 +2432,7 @@ tls.generateKeys = function(c, sp) {
   if(tls12) { // TLS 1.2
     switch(sp.prf_algorithm) {
       case tls.PRFAlgorithm.tls_prf_sha256:
-        prf = prf_sha256;
+        prf = prf_TLS12_sha256;
         break;
       default:
         // should never happen
@@ -3361,24 +3363,25 @@ tls.createFinished = function(c) {
   var b = forge.util.createBuffer();
   var client = (c.entity === tls.ConnectionEnd.client);
   var sp = c.session.sp;
-  var vdl = 12;
+  var vdl = 12; // Same as in TLS1.1 -- see https://tools.ietf.org/html/rfc5246#page-5
   var tls12 = (c.version.major===tls.Versions.TLS_1_2.major &&
                c.version.minor===tls.Versions.TLS_1_2.minor);
+  var prf = null;
 
   if(tls12) {
+      // Defined PRFs for 1.2 use a SHA256 digest -- see https://tools.ietf.org/html/rfc5246#page-5
       switch(sp.mac_algorithm) {
           case tls.MACAlgorithm.hmac_sha256:
-            b.putBuffer(c.session.sha256.digest());
-            break;
           case tls.MACAlgorithm.hmac_sha1:
           default:
-            b.putBuffer(c.session.sha1.digest());
+            b.putBuffer(c.session.sha256.digest());
       }
+      prf = prf_TLS12_sha256;
   } else {
       b.putBuffer(c.session.md5.digest());
       b.putBuffer(c.session.sha1.digest());
+      prf = prf_TLS1;
   }
-  var prf = tls12?prf_sha256:prf_TLS1;
   var label = client ? 'client finished' : 'server finished';
   b = prf(sp.master_secret, label, b.getBytes(), vdl);
 
@@ -4241,7 +4244,7 @@ for(var key in tls) {
 
 // expose prf_tls1 for testing
 forge.tls.prf_tls1 = prf_TLS1;
-forge.tls.prf_sha256 = prf_sha256;
+forge.tls.prf_tls12 = prf_TLS12;
 
 // expose sha1 hmac method
 forge.tls.hmac_sha1 = hmac_sha1;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -2108,7 +2108,8 @@ tls.handleHandshake = function(c, record) {
         serverCertificate: null,
         clientCertificate: null,
         md5: forge.md.md5.create(),
-        sha1: forge.md.sha1.create()
+        sha1: forge.md.sha1.create(),
+        sha256: forge.md.sha1.create()
       };
     }
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -238,6 +238,7 @@ require('./pem');
 require('./pki');
 require('./random');
 require('./sha1');
+require('./sha256');
 require('./util');
 
 /**
@@ -358,7 +359,32 @@ var prf_TLS1 = function(secret, label, seed, length) {
  * @return the pseudo random bytes in a byte buffer.
  */
 var prf_sha256 = function(secret, label, seed, length) {
-   // FIXME: implement me for TLS 1.2
+   var rval = forge.util.createBuffer();
+
+   var ai = forge.util.createBuffer();
+   var sha256bytes = forge.util.createBuffer();
+   var hmac = forge.hmac.create();
+   seed = label + seed;
+
+   var sha256itr = Math.ceil(length / 32);
+
+   hmac.start('SHA256', secret);
+   ai.clear();
+   ai.putBytes(seed);
+   for(var i = 0; i < sha256itr; ++i) {
+     // HMAC_hash(secret, A(i-1))
+     hmac.start(null, null);
+     hmac.update(ai.getBytes());
+     ai.putBuffer(hmac.digest());
+
+     // HMAC_hash(secret, A(i) + seed)
+     hmac.start(null, null);
+     hmac.update(ai.bytes() + seed);
+     sha256bytes.putBuffer(hmac.digest());
+   }
+   rval.putBytes(sha256bytes.getBytes(length));
+
+   return rval;
 };
 
 /**
@@ -391,6 +417,21 @@ var hmac_sha1 = function(key, seqNum, record) {
   b.putBytes(record.fragment.bytes());
   hmac.update(b.getBytes());
   return hmac.digest().getBytes();
+};
+
+var hmac_sha256 = function(key, seqNum, record) {
+    var hmac = forge.hmac.create();
+    hmac.start('SHA256', key);
+    var b = forge.util.createBuffer();
+    b.putInt32(seqNum[0]);
+    b.putInt32(seqNum[1]);
+    b.putByte(record.type);
+    b.putByte(record.version.major);
+    b.putByte(record.version.minor);
+    b.putInt16(record.length);
+    b.putBytes(record.fragment.bytes());
+    hmac.update(b.getBytes());
+    return hmac.digest().getBytes();
 };
 
 /**
@@ -511,6 +552,7 @@ tls.Versions = {
   TLS_1_2: {major: 3, minor: 3}
 };
 tls.SupportedVersions = [
+  tls.Versions.TLS_1_2,
   tls.Versions.TLS_1_1,
   tls.Versions.TLS_1_0
 ];
@@ -708,6 +750,10 @@ tls.HeartbeatMessageType = {
  */
 tls.CipherSuites = {};
 
+tls.usingTLS12 = function (c) {
+    return (c.session.version.major === tls.Versions.TLS_1_2.major &&
+            c.session.version.minor === tls.Versions.TLS_1_2.minor);
+};
 /**
  * Gets a supported cipher suite from its 2 byte ID.
  *
@@ -926,6 +972,7 @@ tls.createSecurityParameters = function(c, msg) {
   /* Note: security params are from TLS 1.2, some values like prf_algorithm
   are ignored for TLS 1.0/1.1 and the builtin as specified in the spec is
   used. */
+  var tls12 = tls.usingTLS12(c);
 
   // TODO: handle other options from server when more supported
 
@@ -1477,6 +1524,8 @@ tls.handleClientKeyExchange = function(c, record, length) {
  * @param length the length of the handshake message.
  */
 tls.handleCertificateRequest = function(c, record, length) {
+  var tls12 = tls.usingTLS12(c);
+
   // minimum of 3 bytes in message
   if(length < 3) {
     return c.error(c, {
@@ -1800,6 +1849,7 @@ tls.handleChangeCipherSpec = function(c, record) {
  * @param length the length of the handshake message.
  */
 tls.handleFinished = function(c, record, length) {
+  var tls12 = tls.usingTLS12(c);
   // rewind to get full bytes for message so it can be manually
   // digested below (special case for Finished messages because they
   // must be digested *after* handling as opposed to all others)
@@ -1810,20 +1860,33 @@ tls.handleFinished = function(c, record, length) {
 
   // message contains only verify_data
   var vd = record.fragment.getBytes();
+  var prf = prf_TLS1;
 
   // ensure verify data is correct
   b = forge.util.createBuffer();
+  if(tls12) {
+    prf = prf_sha256;
+    switch(c.session.sp.mac_algorithm) {
+      case tls.MACAlgorithm.hmac_sha256:
+        b.putBuffer(c.session.sha256.digest());
+        break;
+      case tls.MACAlgorithm.hmac_sha1:
+        b.putBuffer(c.session.sha1.digest());
+        break;
+      default:
+        throw new Exception('Bad MACAlgorithm');
+    }
+  } else {
   b.putBuffer(c.session.md5.digest());
   b.putBuffer(c.session.sha1.digest());
+  }
 
   // set label based on entity type
   var client = (c.entity === tls.ConnectionEnd.client);
   var label = client ? 'server finished' : 'client finished';
 
-  // TODO: determine prf function and verify length for TLS 1.2
   var sp = c.session.sp;
   var vdl = 12;
-  var prf = prf_TLS1;
   b = prf(sp.master_secret, label, b.getBytes(), vdl);
   if(b.getBytes() !== vd) {
     return c.error(c, {
@@ -1839,6 +1902,7 @@ tls.handleFinished = function(c, record, length) {
   // digest finished message now that it has been handled
   c.session.md5.update(msgBytes);
   c.session.sha1.update(msgBytes);
+  c.session.sha256.update(msgBytes);
 
   // resuming session as client or NOT resuming session as server
   if((c.session.resuming && client) || (!c.session.resuming && !client)) {
@@ -2058,6 +2122,7 @@ tls.handleHandshake = function(c, record) {
       type !== tls.HandshakeType.finished) {
       c.session.md5.update(bytes);
       c.session.sha1.update(bytes);
+      c.session.sha256.update(bytes);
     }
 
     // handle specific handshake type record
@@ -2358,22 +2423,21 @@ tls.generateKeys = function(c, sp) {
   // TLS 1.0 but we don't care right now because AES is better and we have
   // an implementation for it
 
-  // TODO: TLS 1.2 implementation
-  /*
   // determine the PRF
-  var prf;
-  switch(sp.prf_algorithm) {
-  case tls.PRFAlgorithm.tls_prf_sha256:
-    prf = prf_sha256;
-    break;
-  default:
-    // should never happen
-    throw new Error('Invalid PRF');
+  var tls12 = tls.usingTLS12(c);
+  var prf = null; // TLS 1.0/1.1 implementation
+  if(tls12) { // TLS 1.2
+    switch(sp.prf_algorithm) {
+      case tls.PRFAlgorithm.tls_prf_sha256:
+        prf = prf_sha256;
+        break;
+      default:
+        // should never happen
+        throw new Error('Invalid PRF');
+    }
+  } else {
+    prf = prf_TLS1;
   }
-  */
-
-  // TLS 1.0/1.1 implementation
-  var prf = prf_TLS1;
 
   // concatenate server and client random
   var random = sp.client_random + sp.server_random;
@@ -3294,14 +3358,26 @@ tls.createChangeCipherSpec = function() {
 tls.createFinished = function(c) {
   // generate verify_data
   var b = forge.util.createBuffer();
-  b.putBuffer(c.session.md5.digest());
-  b.putBuffer(c.session.sha1.digest());
-
-  // TODO: determine prf function and verify length for TLS 1.2
   var client = (c.entity === tls.ConnectionEnd.client);
   var sp = c.session.sp;
   var vdl = 12;
-  var prf = prf_TLS1;
+  var tls12 = (c.version.major===tls.Versions.TLS_1_2.major &&
+               c.version.minor===tls.Versions.TLS_1_2.minor);
+
+  if(tls12) {
+      switch(sp.mac_algorithm) {
+          case tls.MACAlgorithm.hmac_sha256:
+            b.putBuffer(c.session.sha256.digest());
+            break;
+          case tls.MACAlgorithm.hmac_sha1:
+          default:
+            b.putBuffer(c.session.sha1.digest());
+      }
+  } else {
+      b.putBuffer(c.session.md5.digest());
+      b.putBuffer(c.session.sha1.digest());
+  }
+  var prf = tls12?prf_sha256:prf_TLS1;
   var label = client ? 'client finished' : 'server finished';
   b = prf(sp.master_secret, label, b.getBytes(), vdl);
 
@@ -3398,6 +3474,7 @@ tls.queue = function(c, record) {
     var bytes = record.fragment.bytes();
     c.session.md5.update(bytes);
     c.session.sha1.update(bytes);
+    c.session.sha256.update(bytes);
     bytes = null;
   }
 
@@ -3984,7 +4061,8 @@ tls.createConnection = function(options) {
         clientCertificate: null,
         sp: {},
         md5: forge.md.md5.create(),
-        sha1: forge.md.sha1.create()
+        sha1: forge.md.sha1.create(),
+        sha256: forge.md.sha256.create()
       };
 
       // use existing session information
@@ -4162,9 +4240,11 @@ for(var key in tls) {
 
 // expose prf_tls1 for testing
 forge.tls.prf_tls1 = prf_TLS1;
+forge.tls.prf_sha256 = prf_sha256;
 
 // expose sha1 hmac method
 forge.tls.hmac_sha1 = hmac_sha1;
+forge.tls.hmac_sha256 = hmac_sha256;
 
 // expose session cache creation
 forge.tls.createSessionCache = tls.createSessionCache;

--- a/tests/unit/tls.js
+++ b/tests/unit/tls.js
@@ -171,5 +171,50 @@ require('../../lib/util');
         };
       }
     });
+
+    it('should test TLS 1.2 PRF (SHA256)', function() {
+      // This test vector is originally from:
+      // http://www.ietf.org/mail-archive/web/tls/current/msg03416.html
+      var secret = forge.util.createBuffer().putBytes(forge.util.hexToBytes("9bbe436ba940f017b17652849a71db35")).getBytes();
+      var seed = forge.util.createBuffer().putBytes(forge.util.hexToBytes("a0ba9f936cda311827a6f796ffd5198c")).getBytes();
+      var label = forge.util.createBuffer().putBytes(forge.util.hexToBytes("74657374206c6162656c")).getBytes();
+
+      var bytes = forge.tls.prf_tls12(secret, label,  seed, 100, "SHA256");
+      var expect =
+        'e3f229ba727be17b8d122620557cd453' +
+        'c2aab21d07c3d495329b52d4e61edb5a' +
+        '6b301791e90d35c9c9a46b4e14baf9af' +
+        '0fa022f7077def17abfd3797c0564bab' +
+        '4fbc91666e9def9b97fce34f796789ba' +
+        'a48082d122ee42c5a72e5a5110fff701' +
+        '87347b66';
+      ASSERT.equal(bytes.toHex(), expect);
+    });
+
+    it('should test TLS 1.2 PRF (SHA512)', function() {
+      // This test vector is originally from:
+      // http://www.ietf.org/mail-archive/web/tls/current/msg03416.html
+      var secret = forge.util.createBuffer().putBytes(forge.util.hexToBytes("b0323523c1853599584d88568bbb05eb")).getBytes();
+      var seed = forge.util.createBuffer().putBytes(forge.util.hexToBytes("d4640e12e4bcdbfb437f03e6ae418ee5")).getBytes();
+      var label = forge.util.createBuffer().putBytes(forge.util.hexToBytes("74657374206c6162656c")).getBytes();
+
+      var bytes = forge.tls.prf_tls12(secret, label,  seed, 196, "SHA512");
+      var expect =
+        '1261f588c798c5c201ff036e7a9cb5ed' +
+        'cd7fe3f94c669a122a4638d7d508b283' +
+        '042df6789875c7147e906d868bc75c45' +
+        'e20eb40c1cf4a1713b27371f68432592' +
+        'f7dc8ea8ef223e12ea8507841311bf68' +
+        '653d0cfc4056d811f025c45ddfa6e6fe' +
+        'c702f054b409d6f28dd0a3233e498da4' +
+        '1a3e75c5630eedbe22fe254e33a1b0e9' +
+        'f6b9826675bec7d01a845658dc9c3975' +
+        '45401d40b9f46c7a400ee1b8f81ca0a6' +
+        '0d1a397a1028bff5d2ef5066126842fb' +
+        '8da4197632bdb54ff6633f86bbc836e6' +
+        '40d4d898';
+      ASSERT.equal(bytes.toHex(), expect);
+    });
+
   });
 })();


### PR DESCRIPTION
This pull request consists of our implementation of TLS1.2 support, which we added for one of our projects. It supports two new cipher suites: TLS_RSA_WITH_AES_128_CBC_SHA256 and TLS_RSA_WITH_AES_256_CBC_SHA256. Tested against the unit test suite and openssl s_server with TLS 1.1 and TLS 1.2 forced, as well as examples/tls.js and examples/imap.js.