### PR TITLE
asn1.equals: Compare all array elements, not just the first

### DIFF
--- a/lib/asn1.js
+++ b/lib/asn1.js
@@ -289,8 +289,8 @@ asn1.equals = function(obj1, obj2, options) {
       if(!asn1.equals(obj1[i], obj2[i])) {
         return false;
       }
-      return true;
     }
+    return true;
   }
 
   if(typeof obj1 !== typeof obj2) {

--- a/lib/asn1.js
+++ b/lib/asn1.js
@@ -446,7 +446,7 @@ asn1.fromDer = function(bytes, options) {
   }
 
   return _fromDer(bytes, bytes.length(), 0, options);
-}
+};
 
 /**
  * Internal function to parse an asn1 object from a byte buffer in DER format.


### PR DESCRIPTION
Discovered by the Closure Compiler:

    $ closure-compiler --jscomp_warning=lintChecks dist/forge.all.js
    […]
    dist/forge.all.js:3551: WARNING - unreachable code
        for(var i = 0; i < obj1.length; ++i) {
                                        ^^^
