### PR TITLE
Fix catastrophic backtracking

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -17,7 +17,7 @@ var form = module.exports = forge.form = forge.form || {};
 /**
  * Regex for parsing a single name property (handles array brackets).
  */
-var _regex = /(.*?)\[(.*?)\]/g;
+var _regex = /([^\[]*?)\[(.*?)\]/g;
 
 /**
  * Parses a single name property into an array with the name and any


### PR DESCRIPTION
One regex in this project was vulnerable
to catastrophic backtracking.

I have replaced it with a safe regex that matches
a nearly-equivalent language.
I believe this language is still correct for the expected input.

This is a fix for #563.