### PR TITLE
Correctly detect webpack when trying to polyfill utils.setImmediate. Fixes regression in #385

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -13,8 +13,10 @@ var util = module.exports = forge.util = forge.util || {};
 
 // define setImmediate and nextTick
 (function() {
-  // use native nextTick
-  if(typeof process !== 'undefined' && process.nextTick) {
+  // use native nextTick (unless we're in webpack)
+  // webpack (or better node-libs-browser polyfill) sets process.browser.
+  // this way we can detect webpack properly
+  if(typeof process !== 'undefined' && process.nextTick && !process.browser) {
     util.nextTick = process.nextTick;
     if(typeof setImmediate === 'function') {
       util.setImmediate = setImmediate;


### PR DESCRIPTION
When using a stock webpack config (which injects `process`), calling
`forge.utils.setImmedate` fails with `invalid calling object` on IE11
and Edge. 

A fix for this was implemented in #390 but the detection didn't
work properly. 

By checking also for `process.browser`, we can now properly
detect a webpack / browser environment and use the proper workaround for
the error (wrapping `setImmediate`)