### PR TITLE
Custom validity period verification date

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -3528,40 +3528,48 @@ var _alertDescToCertError = function(desc) {
  */
 tls.verifyCertificateChain = function(c, chain) {
   try {
-    // verify chain
-    forge.pki.verifyCertificateChain(c.caStore, chain,
-      function verify(vfd, depth, chain) {
-        // convert pki.certificateError to tls alert description
-        var desc = _certErrorToAlertDesc(vfd);
+    // Make a copy of c.verifyOptions so that we can modify options.verify 
+    // without modifying c.verifyOptions.
+    var options = {};
+    for (var key in c.verifyOptions) {
+      options[key] = c.verifyOptions[key];
+    }
 
-        // call application callback
-        var ret = c.verify(c, vfd, depth, chain);
-        if(ret !== true) {
-          if(typeof ret === 'object' && !forge.util.isArray(ret)) {
-            // throw custom error
-            var error = new Error('The application rejected the certificate.');
-            error.send = true;
-            error.alert = {
-              level: tls.Alert.Level.fatal,
-              description: tls.Alert.Description.bad_certificate
-            };
-            if(ret.message) {
-              error.message = ret.message;
-            }
-            if(ret.alert) {
-              error.alert.description = ret.alert;
-            }
-            throw error;
-          }
+    options.verify = function(vfd, depth, chain) {
+      // convert pki.certificateError to tls alert description
+      var desc = _certErrorToAlertDesc(vfd);
 
-          // convert tls alert description to pki.certificateError
-          if(ret !== vfd) {
-            ret = _alertDescToCertError(ret);
+      // call application callback
+      var ret = c.verify(c, vfd, depth, chain);
+      if(ret !== true) {
+        if(typeof ret === 'object' && !forge.util.isArray(ret)) {
+          // throw custom error
+          var error = new Error('The application rejected the certificate.');
+          error.send = true;
+          error.alert = {
+            level: tls.Alert.Level.fatal,
+            description: tls.Alert.Description.bad_certificate
+          };
+          if(ret.message) {
+            error.message = ret.message;
           }
+          if(ret.alert) {
+            error.alert.description = ret.alert;
+          }
+          throw error;
         }
 
-        return ret;
-      });
+        // convert tls alert description to pki.certificateError
+        if(ret !== vfd) {
+          ret = _alertDescToCertError(ret);
+        }
+      }
+
+      return ret;
+    };
+
+    // verify chain
+    forge.pki.verifyCertificateChain(c.caStore, chain, options);
   } catch(ex) {
     // build tls error if not already customized
     var err = ex;
@@ -3718,6 +3726,7 @@ tls.createConnection = function(options) {
     virtualHost: options.virtualHost || null,
     verifyClient: options.verifyClient || false,
     verify: options.verify || function(cn, vfd, dpth, cts) {return vfd;},
+    verifyOptions: options.verifyOptions || {},
     getCertificate: options.getCertificate || null,
     getPrivateKey: options.getPrivateKey || null,
     getSignature: options.getSignature || null,
@@ -4247,6 +4256,10 @@ forge.tls.createSessionCache = tls.createSessionCache;
  *   verifyClient: true to require a client certificate in server mode,
  *     'optional' to request one, false not to (default: false).
  *   verify: a handler used to custom verify certificates in the chain.
+ *   verifyOptions: an object with options for the certificate chain validation.
+ *     See documentation of pki.verifyCertificateChain for possible options.
+ *     verifyOptions.verify is ignored. If you wish to specify a verify handler
+ *     use the verify key.
  *   getCertificate: an optional callback used to get a certificate or
  *     a chain of certificates (as an array).
  *   getPrivateKey: an optional callback used to get a private key.

--- a/lib/x509.js
+++ b/lib/x509.js
@@ -2940,7 +2940,13 @@ pki.certificateError = {
  * @param caStore a certificate store to verify against.
  * @param chain the certificate chain to verify, with the root or highest
  *          authority at the end (an array of certificates).
- * @param verify called for every certificate in the chain.
+ * @param options a callback to be called for every certificate in the chain or 
+ *                  an object with:
+ *                  verify a callback to be called for every certificate in the
+ *                    chain
+ *                  validityCheckDate the date against which the certificate 
+ *                    validity period should be checked. Pass null to not check 
+ *                    the validity period. By default, the current date is used. 
  *
  * The verify callback has the following signature:
  *
@@ -2956,7 +2962,7 @@ pki.certificateError = {
  *
  * @return true if successful, error thrown if not.
  */
-pki.verifyCertificateChain = function(caStore, chain, verify) {
+pki.verifyCertificateChain = function(caStore, chain, options) {
   /* From: RFC3280 - Internet X.509 Public Key Infrastructure Certificate
     Section 6: Certification Path Validation
     See inline parentheticals related to this particular implementation.
@@ -3086,14 +3092,27 @@ pki.verifyCertificateChain = function(caStore, chain, verify) {
        CAs that may appear below a CA before only end-entity certificates
        may be issued. */
 
+  // if a verify callback is passed as the third parameter, package it within 
+  // the options object. This is to support a legacy function signature that 
+  // expected the verify callback as the third parameter.
+  if(typeof options === 'function') {
+    options = {verify: options};
+  }
+  options = options || {};
+
   // copy cert chain references to another array to protect against changes
   // in verify callback
   chain = chain.slice(0);
   var certs = chain.slice(0);
 
-  // get current date
-  var now = new Date();
-
+  var validityCheckDate = options.validityCheckDate;
+  // if no validityCheckDate is specified, default to the current date. Make 
+  // sure to maintain the value null because it indicates that the validity 
+  // period should not be checked.
+  if(typeof validityCheckDate === 'undefined') {
+    validityCheckDate = new Date();  
+  }
+  
   // verify each cert in the chain using its parent, where the parent
   // is either the next in the chain or from the CA store
   var first = true;
@@ -3104,15 +3123,20 @@ pki.verifyCertificateChain = function(caStore, chain, verify) {
     var parent = null;
     var selfSigned = false;
 
-    // 1. check valid time
-    if(now < cert.validity.notBefore || now > cert.validity.notAfter) {
-      error = {
-        message: 'Certificate is not valid yet or has expired.',
-        error: pki.certificateError.certificate_expired,
-        notBefore: cert.validity.notBefore,
-        notAfter: cert.validity.notAfter,
-        now: now
-      };
+    if(validityCheckDate) {
+      // 1. check valid time
+      if(validityCheckDate < cert.validity.notBefore || 
+         validityCheckDate > cert.validity.notAfter) {
+        error = {
+          message: 'Certificate is not valid yet or has expired.',
+          error: pki.certificateError.certificate_expired,
+          notBefore: cert.validity.notBefore,
+          notAfter: cert.validity.notAfter,
+          // TODO: we might want to reconsider renaming 'now' to 
+          // 'validityCheckDate' should this API be changed in the future.
+          now: validityCheckDate
+        };
+      }
     }
 
     // 2. verify with parent from chain or CA store
@@ -3259,7 +3283,7 @@ pki.verifyCertificateChain = function(caStore, chain, verify) {
 
     // call application callback
     var vfd = (error === null) ? true : error.error;
-    var ret = verify ? verify(vfd, depth, certs) : vfd;
+    var ret = options.verify ? options.verify(vfd, depth, certs) : vfd;
     if(ret === true) {
       // clear any set error
       error = null;


### PR DESCRIPTION
## Problem
I would like to be able to check whether a particular certificate chain was valid at a specific date at which the certificate was used to sign a message. 

## Solution
For this I added an additional parameter to `x509.verifyCertificateChain` with which the date at which the certificate's validity shall be checked can be specified. It defaults to the current date.

## Open questions
Passing `validityCheckDate` after the `verify` callback is a bit unfortunate, but adding it before the callback would be a breaking change and I'm not sure how strict you are with breaking changes at this point.