### PR TITLE
x509: add support for Netscape comment extension

### DIFF
--- a/lib/oids.js
+++ b/lib/oids.js
@@ -112,7 +112,7 @@ _IN('2.5.4.13', 'description');
 
 // X.509 extension OIDs
 _IN('2.16.840.1.113730.1.1', 'nsCertType');
-_IN('2.16.840.1.113730.1.13', 'nsComment'); // depreciated in theory; still widely used
+_IN('2.16.840.1.113730.1.13', 'nsComment'); // deprecated in theory; still widely used
 _I_('2.5.29.1', 'authorityKeyIdentifier'); // deprecated, use .35
 _I_('2.5.29.2', 'keyAttributes'); // obsolete use .37 or .15
 _I_('2.5.29.3', 'certificatePolicies'); // deprecated, use .32

--- a/lib/oids.js
+++ b/lib/oids.js
@@ -112,6 +112,7 @@ _IN('2.5.4.13', 'description');
 
 // X.509 extension OIDs
 _IN('2.16.840.1.113730.1.1', 'nsCertType');
+_IN('2.16.840.1.113730.1.13', 'nsComment'); // depreciated in theory; still widely used
 _I_('2.5.29.1', 'authorityKeyIdentifier'); // deprecated, use .35
 _I_('2.5.29.2', 'keyAttributes'); // obsolete use .37 or .15
 _I_('2.5.29.3', 'certificatePolicies'); // deprecated, use .32

--- a/lib/x509.js
+++ b/lib/x509.js
@@ -2274,9 +2274,10 @@ function _fillMissingExtensionFields(e, options) {
     }
   } else if(e.name === 'nsComment' && options.cert) {
     // sanity check value is ASCII (req'd) and not too big
-    if (!(/^[\x00-\x7F]*$/.test(e.comment)) ||
-        (e.comment.length < 1) || (e.comment.length > 128))
-      throw new Error("nsComment invalid content");
+    if(!(/^[\x00-\x7F]*$/.test(e.comment)) ||
+      (e.comment.length < 1) || (e.comment.length > 128)) {
+      throw new Error('Invalid "nsComment" content.');
+    }
     // IA5STRING opaque comment
     e.value = asn1.create(
       asn1.Class.UNIVERSAL, asn1.Type.IA5STRING, false, e.comment);

--- a/lib/x509.js
+++ b/lib/x509.js
@@ -2272,6 +2272,14 @@ function _fillMissingExtensionFields(e, options) {
         asn1.Class.CONTEXT_SPECIFIC, altName.type, false,
         value));
     }
+  } else if(e.name === 'nsComment' && options.cert) {
+    // sanity check value is ASCII (req'd) and not too big
+    if (!(/^[\x00-\x7F]*$/.test(e.comment)) ||
+        (e.comment.length < 1) || (e.comment.length > 128))
+      throw new Error("nsComment invalid content");
+    // IA5STRING opaque comment
+    e.value = asn1.create(
+      asn1.Class.UNIVERSAL, asn1.Type.IA5STRING, false, e.comment);
   } else if(e.name === 'subjectKeyIdentifier' && options.cert) {
     var ski = options.cert.generateSubjectKeyIdentifier();
     e.subjectKeyIdentifier = ski.toHex();

--- a/tests/unit/x509.js
+++ b/tests/unit/x509.js
@@ -467,7 +467,7 @@ var UTIL = require('../../lib/util');
       var pem = PKI.certificateToPem(cert);
       cert = PKI.certificateFromPem(pem);
 
-      // verify cRLDistributionPoints extension
+      // verify nsComment extension
       var index = findIndex(cert.extensions, {id: '2.16.840.1.113730.1.13'});
       ASSERT.ok(index !== -1);
       var ext = cert.extensions[index];


### PR DESCRIPTION
This extension is in theory deprecated, but remains widely used, and
supported by openssl and other tools.  It is a useful method to associate a
comment or memo with a certificate.

OID 2.16.840.1.113730.1.13 requires IA5STRING value for the comment.  We filter
for this requirement, and also to avoid creating pathologically long strings
by default.