### PR TITLE
Use node.crypto.generateKeyPair when available

### DIFF
--- a/lib/rsa.js
+++ b/lib/rsa.js
@@ -894,7 +894,7 @@ pki.rsa.generateKeyPair = function(bits, e, options, callback) {
         modulusLength: bits,
         publicExponent: e,
         publicKeyEncoding: {
-          type: 'pkcs1',
+          type: 'spki',
           format: 'pem'
         },
         privateKeyEncoding: {

--- a/lib/rsa.js
+++ b/lib/rsa.js
@@ -905,10 +905,9 @@ pki.rsa.generateKeyPair = function(bits, e, options, callback) {
         if (err) {
           return callback(err);
         }
-        var privateKey = pki.privateKeyFromPem(priv);
         callback(null, {
-          privateKey: privateKey,
-          publicKey: pki.setRsaPublicKey(privateKey.n, privateKey.e)
+          privateKey: pki.privateKeyFromPem(priv),
+          publicKey: pki.publicKeyFromPem(pub)
         });
       });
     }

--- a/lib/rsa.js
+++ b/lib/rsa.js
@@ -74,6 +74,8 @@ if(typeof BigInteger === 'undefined') {
   var BigInteger = forge.jsbn.BigInteger;
 }
 
+var _crypto = forge.util.isNodejs ? require('crypto') : null;
+
 // shortcut for asn.1 API
 var asn1 = forge.asn1;
 
@@ -887,6 +889,30 @@ pki.rsa.generateKeyPair = function(bits, e, options, callback) {
   // key generation code if available and if parameters are acceptable
   if(!forge.options.usePureJavaScript && callback &&
     bits >= 256 && bits <= 16384 && (e === 0x10001 || e === 3)) {
+    if(forge.util.isNodejs && _detectNodeCrypto('generateKeyPair')) {
+      return _crypto.generateKeyPair('rsa', {
+        modulusLength: bits,
+        publicExponent: e,
+        publicKeyEncoding: {
+          type: 'pkcs1',
+          format: 'der'
+        },
+        privateKeyEncoding: {
+          type: 'pkcs8',
+          format: 'der'
+        }
+      }, function(err, pub, pkcs8) {
+        if (err) {
+          return callback(err);
+        }
+        var privateKey = pki.privateKeyFromAsn1(
+          asn1.fromDer(forge.util.createBuffer(pkcs8)));
+        callback(null, {
+          privateKey: privateKey,
+          publicKey: pki.setRsaPublicKey(privateKey.n, privateKey.e)
+        });
+      });
+    }
     if(_detectSubtleCrypto('generateKey') && _detectSubtleCrypto('exportKey')) {
       // use standard native generateKey
       return window.crypto.subtle.generateKey({
@@ -1725,6 +1751,22 @@ function _getMillerRabinTests(bits) {
   if(bits <= 800) return 4;
   if(bits <= 1250) return 3;
   return 2;
+}
+
+/**
+ * Performs feature detection on the Node crypto interface.
+ *
+ * @param fn the feature (function) to detect.
+ *
+ * @return true if detected, false if not.
+ */
+function _detectNodeCrypto(fn) {
+  try {
+    var crypto = require('crypto');
+    return typeof crypto[fn] === 'function';
+  } catch (err) {
+    return false;
+  }
 }
 
 /**

--- a/lib/rsa.js
+++ b/lib/rsa.js
@@ -889,24 +889,23 @@ pki.rsa.generateKeyPair = function(bits, e, options, callback) {
   // key generation code if available and if parameters are acceptable
   if(!forge.options.usePureJavaScript && callback &&
     bits >= 256 && bits <= 16384 && (e === 0x10001 || e === 3)) {
-    if(forge.util.isNodejs && _detectNodeCrypto('generateKeyPair')) {
+    if(_detectNodeCrypto('generateKeyPair')) {
       return _crypto.generateKeyPair('rsa', {
         modulusLength: bits,
         publicExponent: e,
         publicKeyEncoding: {
           type: 'pkcs1',
-          format: 'der'
+          format: 'pem'
         },
         privateKeyEncoding: {
           type: 'pkcs8',
-          format: 'der'
+          format: 'pem'
         }
-      }, function(err, pub, pkcs8) {
+      }, function(err, pub, priv) {
         if (err) {
           return callback(err);
         }
-        var privateKey = pki.privateKeyFromAsn1(
-          asn1.fromDer(forge.util.createBuffer(pkcs8)));
+        var privateKey = pki.privateKeyFromPem(priv);
         callback(null, {
           privateKey: privateKey,
           publicKey: pki.setRsaPublicKey(privateKey.n, privateKey.e)
@@ -1761,12 +1760,7 @@ function _getMillerRabinTests(bits) {
  * @return true if detected, false if not.
  */
 function _detectNodeCrypto(fn) {
-  try {
-    var crypto = require('crypto');
-    return typeof crypto[fn] === 'function';
-  } catch (err) {
-    return false;
-  }
+  return forge.util.isNodejs && typeof _crypto[fn] === 'function';
 }
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -125,11 +125,6 @@ util.isArrayBufferView = function(x) {
   return x && util.isArrayBuffer(x.buffer) && x.byteLength !== undefined;
 };
 
-// Node versions >= 10.12.0 support native keyPair generation,
-// which is non-deterministic
-util.isDeterministic = util.isNodejs &&
-  typeof require('crypto').generateKeyPair !== 'function';
-
 /**
  * Ensure a bits param is 8, 16, 24, or 32. Used to validate input for
  * algorithms where bit manipulation, JavaScript limitations, and/or algorithm

--- a/lib/util.js
+++ b/lib/util.js
@@ -125,6 +125,11 @@ util.isArrayBufferView = function(x) {
   return x && util.isArrayBuffer(x.buffer) && x.byteLength !== undefined;
 };
 
+// Node versions >= 10.2 support native keyPair generation,
+// which is non-deterministic
+util.isDeterministic = util.isNodejs &&
+  typeof require('crypto').generateKeyPair !== 'function';
+
 /**
  * Ensure a bits param is 8, 16, 24, or 32. Used to validate input for
  * algorithms where bit manipulation, JavaScript limitations, and/or algorithm

--- a/lib/util.js
+++ b/lib/util.js
@@ -125,7 +125,7 @@ util.isArrayBufferView = function(x) {
   return x && util.isArrayBuffer(x.buffer) && x.byteLength !== undefined;
 };
 
-// Node versions >= 10.2 support native keyPair generation,
+// Node versions >= 10.12.0 support native keyPair generation,
 // which is non-deterministic
 util.isDeterministic = util.isNodejs &&
   typeof require('crypto').generateKeyPair !== 'function';

--- a/tests/unit/rsa.js
+++ b/tests/unit/rsa.js
@@ -189,7 +189,7 @@ var UTIL = require('../../lib/util');
       var pair1 = _genSync({samePrng: true});
       _genAsync({samePrng: true}, function(pair2) {
         // check if the same on supported deterministic platforms
-        if(UTIL.isNodejs) {
+        if(UTIL.isDeterministic) {
           _pairCmp(pair1, pair2);
         }
         done();
@@ -200,7 +200,7 @@ var UTIL = require('../../lib/util');
       _genAsync({samePrng: true}, function(pair1) {
         var pair2 = _genSync({samePrng: true});
         // check if the same on supported deterministic platforms
-        if(UTIL.isNodejs) {
+        if(UTIL.isDeterministic) {
           _pairCmp(pair1, pair2);
         }
         done();
@@ -214,7 +214,7 @@ var UTIL = require('../../lib/util');
       function _done() {
         if(pair1 && pair2) {
           // check if the same on supported deterministic platforms
-          if(UTIL.isNodejs) {
+          if(UTIL.isDeterministic) {
             _pairCmp(pair1, pair2);
           }
           done();

--- a/tests/unit/rsa.js
+++ b/tests/unit/rsa.js
@@ -127,6 +127,11 @@ var UTIL = require('../../lib/util');
       });
     }
 
+    // Node versions >= 10.12.0 support native keyPair generation,
+    // which is non-deterministic
+    var isDeterministic = UTIL.isNodejs &&
+      typeof require('crypto').generateKeyPair !== 'function';
+
     it('should generate 512 bit key pair (sync)', function() {
       _genSync();
     });
@@ -189,7 +194,7 @@ var UTIL = require('../../lib/util');
       var pair1 = _genSync({samePrng: true});
       _genAsync({samePrng: true}, function(pair2) {
         // check if the same on supported deterministic platforms
-        if(UTIL.isDeterministic) {
+        if(isDeterministic) {
           _pairCmp(pair1, pair2);
         }
         done();
@@ -200,7 +205,7 @@ var UTIL = require('../../lib/util');
       _genAsync({samePrng: true}, function(pair1) {
         var pair2 = _genSync({samePrng: true});
         // check if the same on supported deterministic platforms
-        if(UTIL.isDeterministic) {
+        if(isDeterministic) {
           _pairCmp(pair1, pair2);
         }
         done();
@@ -214,7 +219,7 @@ var UTIL = require('../../lib/util');
       function _done() {
         if(pair1 && pair2) {
           // check if the same on supported deterministic platforms
-          if(UTIL.isDeterministic) {
+          if(isDeterministic) {
             _pairCmp(pair1, pair2);
           }
           done();


### PR DESCRIPTION
Node >= 10.12.0 has a native `crypto.generateKeyPair` that's quite a bit faster (like, 10-20x) than pure JS.

Apologies if this PR is missing something. This was my first time digging into Forge.