### PR TITLE
README: Remove circular documentation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,6 @@ forge you need.
 Testing
 -------
 
-See the [testing README](./tests/README.md) for full details.
-
 ### Prepare to run tests
 
     npm install


### PR DESCRIPTION
Main README references testing README, which is a one-line file
pointing the reader back to main.