### PR TITLE
Switch tests from PhantomJS to headless Chrome.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Forge ChangeLog
   - Use JS fallback in `rsa.generateKeyPair` if `prng` option specified since
     this isn't supported by current native APIs.
   - Only run key generation comparison tests if keys will be deterministic.
+- PhantomJS is deprecated, now using headless Chrome with Karma.
+- **Note**: Using headless Chrome vs PhantomJS may cause newer JS features to
+  slip into releases without proper support for older runtimes and browsers.
+  Please report such issues and they will be addressed.
 
 ## 0.7.6 - 2018-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ Forge ChangeLog
   - Use JS fallback in `rsa.generateKeyPair` if `prng` option specified since
     this isn't supported by current native APIs.
   - Only run key generation comparison tests if keys will be deterministic.
-- PhantomJS is deprecated, now using headless Chrome with Karma.
-- **Note**: Using headless Chrome vs PhantomJS may cause newer JS features to
+- PhantomJS is deprecated, now using Headless Chrome with Karma.
+- **Note**: Using Headless Chrome vs PhantomJS may cause newer JS features to
   slip into releases without proper support for older runtimes and browsers.
   Please report such issues and they will be addressed.
 

--- a/README.md
+++ b/README.md
@@ -219,10 +219,10 @@ Forge natively runs in a [Node.js][] environment:
 
     npm test
 
-### Running automated tests with PhantomJS
+### Running automated tests with headless Chrome
 
 Automated testing is done via [Karma][]. By default it will run the tests in a
-headless manner with PhantomJS.
+headless manner with Chrome.
 
     npm run test-karma
 
@@ -239,7 +239,7 @@ By default [webpack][] is used. [Browserify][] can also be used.
 
 You can also specify one or more browsers to use.
 
-    npm run test-karma -- --browsers Chrome,Firefox,Safari,PhantomJS
+    npm run test-karma -- --browsers Chrome,Firefox,Safari,ChromeHeadless
 
 The reporter option and `BUNDLER` environment variable can also be used.
 

--- a/README.md
+++ b/README.md
@@ -219,10 +219,10 @@ Forge natively runs in a [Node.js][] environment:
 
     npm test
 
-### Running automated tests with headless Chrome
+### Running automated tests with Headless Chrome
 
-Automated testing is done via [Karma][]. By default it will run the tests in a
-headless manner with Chrome.
+Automated testing is done via [Karma][]. By default it will run the tests with
+Headless Chrome.
 
     npm run test-karma
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -89,8 +89,8 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    //browsers: ['PhantomJS', 'Chrome', 'Firefox', 'Safari'],
-    browsers: ['PhantomJS'],
+    //browsers: ['ChromeHeadless', 'Chrome', 'Firefox', 'Safari'],
+    browsers: ['ChromeHeadless'],
 
     customLaunchers: {
       IE9: {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "karma-ie-launcher": "^1.0.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
-    "karma-phantomjs-launcher": "^1.0.2",
     "karma-safari-launcher": "^1.0.0",
     "karma-sauce-launcher": "^1.2.0",
     "karma-sourcemap-loader": "^0.3.7",

--- a/tests/unit/asn1.js
+++ b/tests/unit/asn1.js
@@ -1,7 +1,6 @@
 var ASSERT = require('assert');
 var ASN1 = require('../../lib/asn1');
 var UTIL = require('../../lib/util');
-var support = require('./support');
 
 (function() {
   describe('asn1', function() {
@@ -209,10 +208,6 @@ var support = require('./support');
     })();
 
     (function() {
-      // TODO: remove skipping PhantomJS tests when possible
-      // skip 2050 tests in PhantomJS
-      // likely due to https://bugs.webkit.org/show_bug.cgi?id=130123
-      // can't parse dates between 2034-03-01 and 2100-02-28
       var tests = [{
         in: 'Jan 1 1949 00:00:00 GMT',
         out: '19490101000000Z'
@@ -221,15 +216,13 @@ var support = require('./support');
         out: '20000101000000Z'
       }, {
         in: 'Jan 1 2050 00:00:00 GMT',
-        out: '20500101000000Z',
-        phantomjsskip: true
+        out: '20500101000000Z'
       }, {
         in: 'Mar 1 2100 00:00:00 GMT',
         out: '21000301000000Z'
       }];
       tests.forEach(function(test) {
-        var _it = (test.phantomjsskip && support.isPhantomJS) ? it.skip : it;
-        _it('should convert date "' + test.in + '" to generalized time', function() {
+        it('should convert date "' + test.in + '" to generalized time', function() {
           var d = ASN1.dateToGeneralizedTime(new Date(test.in));
           ASSERT.equal(d, test.out);
         });

--- a/tests/unit/pkcs7.js
+++ b/tests/unit/pkcs7.js
@@ -5,7 +5,6 @@ var PKI = require('../../lib/pki');
 var AES = require('../../lib/aes');
 var DES = require('../../lib/des');
 var UTIL = require('../../lib/util');
-var support = require('./support');
 
 (function() {
   var _pem = {
@@ -702,13 +701,7 @@ var support = require('./support');
       ASSERT.equal(pem, _pem.detachedSignature);
     });
 
-    // FIXME: remove skipping PhantomJS tests when possible
-    // skip 2049/2050 tests in PhantomJS
-    // likely due to https://bugs.webkit.org/show_bug.cgi?id=130123
-    // can't parse dates between 2034-03-01 and 2100-02-28
-    var _it = support.isPhantomJS ? it.skip : it;
-
-    _it('should create PKCS#7 SignedData with content-type, message-digest, ' +
+    it('should create PKCS#7 SignedData with content-type, message-digest, ' +
       'and signing-time attributes using UTCTime (2049)', function() {
       // verify with:
       // openssl smime -verify -in p7.pem -signer certificate.pem \
@@ -737,7 +730,7 @@ var support = require('./support');
       ASSERT.equal(pem, _pem.signedDataWithAttrs2049UTCTime);
     });
 
-    _it('should create PKCS#7 SignedData with content-type, message-digest, ' +
+    it('should create PKCS#7 SignedData with content-type, message-digest, ' +
       'and signing-time attributes using GeneralizedTime (2050)', function() {
       // verify with:
       // openssl smime -verify -in p7.pem -signer certificate.pem \

--- a/tests/unit/support.js
+++ b/tests/unit/support.js
@@ -1,7 +1,0 @@
-// test support
-
-// true if running in PhantomJS
-exports.isPhantomJS =
-  (typeof navigator !== 'undefined' && navigator.userAgent) ?
-  navigator.userAgent.indexOf('PhantomJS') !== -1 :
-  false;


### PR DESCRIPTION
- PhantomJS is deprecated. Now using headless Chrome.
- See also: https://github.com/digitalbazaar/forge/pull/616