### PR TITLE
PKCS#7: Custom message digest

### DIFF
--- a/lib/pkcs7.js
+++ b/lib/pkcs7.js
@@ -444,43 +444,41 @@ p7.createSignedData = function() {
   }
 
   function addSignerInfos(mds) {
-    var content;
+    var content,
+        bytes;
 
-    if (msg.detachedContent) {
-      // Signature has been made in detached mode.
-      content = msg.detachedContent;
-    } else {
-      // Note: ContentInfo is a SEQUENCE with 2 values, second value is
-      // the content field and is optional for a ContentInfo but required here
-      // since signers are present
-      // get ContentInfo content
-      content = msg.contentInfo.value[1];
-      // skip [0] EXPLICIT content wrapper
-      content = content.value[0];
-    }
+    if (msg.content) {
+      if (msg.detachedContent) {
+        // Signature has been made in detached mode.
+        content = msg.detachedContent;
+      } else {
+        // Note: ContentInfo is a SEQUENCE with 2 values, second value is
+        // the content field and is optional for a ContentInfo but required here
+        // since signers are present
+        // get ContentInfo content
+        content = msg.contentInfo.value[1];
+        // skip [0] EXPLICIT content wrapper
+        content = content.value[0];
+      }
 
-    if(!content) {
-      throw new Error(
-        'Could not sign PKCS#7 message; there is no content to sign.');
+      // serialize content
+      bytes = asn1.toDer(content);
+  
+      // skip identifier and length per RFC 2315 9.3
+      // skip identifier (1 byte)
+      bytes.getByte();
+      // read and discard length bytes
+      asn1.getBerValueLength(bytes);
+      bytes = bytes.getBytes();
+  
+      // digest content DER value bytes
+      for(var oid in mds) {
+        mds[oid].start().update(bytes);
+      }
     }
 
     // get ContentInfo content type
     var contentType = asn1.derToOid(msg.contentInfo.value[0].value);
-
-    // serialize content
-    var bytes = asn1.toDer(content);
-
-    // skip identifier and length per RFC 2315 9.3
-    // skip identifier (1 byte)
-    bytes.getByte();
-    // read and discard length bytes
-    asn1.getBerValueLength(bytes);
-    bytes = bytes.getBytes();
-
-    // digest content DER value bytes
-    for(var oid in mds) {
-      mds[oid].start().update(bytes);
-    }
 
     // sign content
     var signingTime = new Date();
@@ -509,8 +507,15 @@ p7.createSignedData = function() {
         for(var ai = 0; ai < signer.authenticatedAttributes.length; ++ai) {
           var attr = signer.authenticatedAttributes[ai];
           if(attr.type === forge.pki.oids.messageDigest) {
-            // use content message digest as value
-            attr.value = mds[signer.digestAlgorithm].digest();
+            // use content message digest as value if not already set
+            if(!attr.value){
+              if(!content) {
+                throw new Error(
+                  'Could not sign PKCS#7 message; there is no content to ' +
+                  'sign or message-digest attribute missing.');
+              }
+              attr.value = mds[signer.digestAlgorithm].digest();
+            }
           } else if(attr.type === forge.pki.oids.signingTime) {
             // auto-populate signing time if not already set
             if(!attr.value) {


### PR DESCRIPTION
### Problem

If one is doing an detached signing, buffering the whole data to sign it is really inconvenient.

### Solution

My approach here is to allow a user-definied message digest, so you can code something like this: 

```js
const hash = crypto.createHash('sha512');
  
stream.on('data', chunk => hash.update(chunk));
stream.on('end', () => {
  const messageDigest = forge.util.createBuffer(hash.digest().toString('binary'));
  const p7 = pkcs7.createSignedData();
  
  p7.addSigner({
    key: privateKey,
    certificate: certificate,
    digestAlgorithm: forge.pki.oids.sha512,
    authenticatedAttributes: [{
      type: forge.pki.oids.contentType,
      value: forge.pki.oids.data
    },{
      type: forge.pki.oids.signingTime,
      value: new Date()
    },{
      type: forge.pki.oids.messageDigest,
      value: messageDigest
    }]
  });
  p7.sign({ detached: true });
});
```

Maybe a better way to solve this is by allowing `p7.content` to be able to receive a data stream, but for now this seems to solve the problem quite well.