### PR TITLE
Remove non breaking space from tls.js -- this causes issues on some browsers

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -3528,7 +3528,7 @@ var _alertDescToCertError = function(desc) {
  */
 tls.verifyCertificateChain = function(c, chain) {
   try {
-    // Make a copy of c.verifyOptions so that we can modify options.verify 
+    // Make a copy of c.verifyOptions so that we can modify options.verify
     // without modifying c.verifyOptions.
     var options = {};
     for (var key in c.verifyOptions) {
@@ -3726,7 +3726,7 @@ tls.createConnection = function(options) {
     virtualHost: options.virtualHost || null,
     verifyClient: options.verifyClient || false,
     verify: options.verify || function(cn, vfd, dpth, cts) {return vfd;},
-    verifyOptions: options.verifyOptions || {},
+    verifyOptions: options.verifyOptions || {},
     getCertificate: options.getCertificate || null,
     getPrivateKey: options.getPrivateKey || null,
     getSignature: options.getSignature || null,


### PR DESCRIPTION
Various files are encoded differently - I am not sure if this is intentional:

```
aes.js: UTF-8 Unicode text
aesCipherSuites.js: ASCII text
asn1.js: ASCII text
baseN.js: Algol 68 source text, ASCII text
cipher.js: ASCII text
cipherModes.js: Algol 68 source text, ASCII text
debug.js: ASCII text
des.js: ASCII text, with very long lines
ed25519.js: ASCII text
forge.js: ASCII text
form.js: Algol 68 source text, ASCII text
hmac.js: ASCII text
http.js: ASCII text
index.all.js: ASCII text
index.js: ASCII text
jsbn.js: ASCII text, with very long lines
kem.js: ASCII text
log.js: ASCII text
md.all.js: ASCII text
md.js: ASCII text
md5.js: ASCII text
mgf.js: ASCII text
mgf1.js: ASCII text
oids.js: ASCII text
pbe.js: ASCII text
pbkdf2.js: ASCII text
pem.js: ASCII text
pkcs1.js: ASCII text
pkcs12.js: UTF-8 Unicode text
pkcs7.js: ASCII text
pkcs7asn1.js: ASCII text
pki.js: ASCII text
prime.js: ASCII text
prime.worker.js: ASCII text, with very long lines
prng.js: ASCII text
pss.js: ASCII text
random.js: ASCII text
rc2.js: ASCII text
rsa.js: ASCII text
sha1.js: ASCII text
sha256.js: ASCII text
sha512.js: ASCII text
socket.js: ASCII text
ssh.js: ASCII text
task.js: ASCII text
tls.js: UTF-8 Unicode text
tlssocket.js: ASCII text
util.js: ASCII text
x509.js: ASCII text
xhr.js: c program text, ASCII text
```

`tls.js` in particular has a [non-breaking space](https://en.wikipedia.org/wiki/Non-breaking_space) that causes an issue - here is the output as seen in chrome extensions:

```
// create TLS connection
  var c = {
    version: {major: tls.Version.major, minor: tls.Version.minor},
    entity: entity,
    sessionId: options.sessionId,
    caStore: caStore,
    sessionCache: sessionCache,
    cipherSuites: cipherSuites,
    connected: options.connected,
    virtualHost: options.virtualHost || null,
    verifyClient: options.verifyClient || false,
    verify: options.verify || function(cn, vfd, dpth, cts) {return vfd;},
    verifyOptions: options.verifyOptions ||Â {},
    getCertificate: options.getCertificate || null,
```
note the `Â` character on the `verifyOptions` line.  

I am not sure if this is a browser issue, a webpack issue, or babel issue. (See https://stackoverflow.com/questions/46035896/nbsp-in-jsx-file-being-translated-to-%C3%82-in-some-browsers) 

Regardless, not sure why there's a non-breaking space in the source.


