### PR TITLE
Deprecated node buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Forge ChangeLog
 
 ## 0.8.4 -
 
-### Removed
+### Changed
 - Replace all instances of Node.js `new Buffer` with `Buffer.from` and `Buffer.alloc`.
 
 ## 0.8.3 - 2019-05-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Forge ChangeLog
 ## 0.8.4 -
 
 ### Removed
-- All instances of Node.js `new Buffer` in favor of `Buffer.from` and `Buffer.alloc`.
+- Replace all instances of Node.js `new Buffer` with `Buffer.from` and `Buffer.alloc`.
 
 ## 0.8.3 - 2019-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Forge ChangeLog
 ## 0.8.4 -
 
 ### Removed
-- All instances of node new Buffer in favor of Buffer.from and Buffer.alloc
+- All instances of Node.js `new Buffer` in favor of `Buffer.from` and `Buffer.alloc`.
 
 ## 0.8.3 - 2019-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Forge ChangeLog
 ===============
 
+
+## 0.8.4 -
+
+### Removed
+- All instances of node new Buffer in favor of Buffer.from and Buffer.alloc
+
 ## 0.8.3 - 2019-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1965,7 +1965,7 @@ var nodeBuffer = Buffer.from(forgeBuffer.getBytes(), 'binary');
 
 // convert a Node.js Buffer into a forge buffer
 // make sure you specify the encoding as 'binary'
-var nodeBuffer = Buffer.alloc(10);
+var nodeBuffer = Buffer.from('CAFE', 'hex');
 var forgeBuffer = forge.util.createBuffer(nodeBuffer.toString('binary'));
 
 // parse a URL

--- a/README.md
+++ b/README.md
@@ -904,7 +904,7 @@ var signature = ED25519.sign({
 // sign a message passed as a buffer
 var signature = ED25519.sign({
   // also accepts a forge ByteBuffer or Uint8Array
-  message: new Buffer('test', 'utf8'),
+  message: Buffer.from('test', 'utf8'),
   privateKey: privateKey
 });
 
@@ -930,7 +930,7 @@ var verified = ED25519.verify({
 // sign a message passed as a buffer
 var verified = ED25519.verify({
   // also accepts a forge ByteBuffer or Uint8Array
-  message: new Buffer('test', 'utf8'),
+  message: Buffer.from('test', 'utf8'),
   // node.js Buffer, Uint8Array, forge ByteBuffer, or binary string
   signature: signature,
   // node.js Buffer, Uint8Array, forge ByteBuffer, or binary string
@@ -1961,11 +1961,11 @@ bytes.getBytes(/* count */);
 // convert a forge buffer into a Node.js Buffer
 // make sure you specify the encoding as 'binary'
 var forgeBuffer = forge.util.createBuffer();
-var nodeBuffer = new Buffer(forgeBuffer.getBytes(), 'binary');
+var nodeBuffer = Buffer.from(forgeBuffer.getBytes(), 'binary');
 
 // convert a Node.js Buffer into a forge buffer
 // make sure you specify the encoding as 'binary'
-var nodeBuffer = new Buffer();
+var nodeBuffer = Buffer.alloc(10);
 var forgeBuffer = forge.util.createBuffer(nodeBuffer.toString('binary'));
 
 // parse a URL

--- a/lib/asn1.js
+++ b/lib/asn1.js
@@ -619,7 +619,7 @@ function _fromDer(bytes, remaining, depth, options) {
   }
 
   // add BIT STRING contents if available
-  var asn1Options = bitStringContents === undefined ?  null : {
+  var asn1Options = bitStringContents === undefined ? null : {
     bitStringContents: bitStringContents
   };
 

--- a/lib/ed25519.js
+++ b/lib/ed25519.js
@@ -168,7 +168,7 @@ function messageToNativeBuffer(options) {
 
   if(typeof message === 'string') {
     if(typeof Buffer !== 'undefined') {
-      return new Buffer(message, encoding);
+      return Buffer.from(message, encoding);
     }
     message = new ByteBuffer(message, encoding);
   } else if(!(message instanceof ByteBuffer)) {
@@ -217,7 +217,7 @@ function sha512(msg, msgLen) {
   md.update(buffer.getBytes(msgLen), 'binary');
   var hash = md.digest().getBytes();
   if(typeof Buffer !== 'undefined') {
-    return new Buffer(hash, 'binary');
+    return Buffer.from(hash, 'binary');
   }
   var out = new NativeBuffer(ed25519.constants.HASH_BYTE_LENGTH);
   for(var i = 0; i < 64; ++i) {

--- a/lib/pbkdf2.js
+++ b/lib/pbkdf2.js
@@ -51,8 +51,8 @@ module.exports = forge.pbkdf2 = pkcs5.pbkdf2 = function(
       // default prf to SHA-1
       md = 'sha1';
     }
-    p = new Buffer(p, 'binary');
-    s = new Buffer(s, 'binary');
+    p = Buffer.from(p, 'binary');
+    s = Buffer.from(s, 'binary');
     if(!callback) {
       if(crypto.pbkdf2Sync.length === 4) {
         return crypto.pbkdf2Sync(p, s, c, dkLen).toString('binary');

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "dist/*.min.js.map"
   ],
   "engines": {
-    "node": "*"
+    "node": ">= 4.5.0"
   },
   "keywords": [
     "aes",

--- a/tests/benchmarks/so-44303784.js
+++ b/tests/benchmarks/so-44303784.js
@@ -63,9 +63,9 @@ function test_forge_chunk(bytes, chunkSize) {
 }
 
 function test_node(bytes) {
-  const bufb = new Buffer(bytes, 'binary');
-  const ivb = new Buffer(iv, 'binary');
-  const keyb = new Buffer(key, 'binary');
+  const bufb = Buffer.from(bytes, 'binary');
+  const ivb = Buffer.from(iv, 'binary');
+  const keyb = Buffer.from(key, 'binary');
 
   const start = new Date();
 

--- a/tests/unit/ed25519.js
+++ b/tests/unit/ed25519.js
@@ -127,7 +127,7 @@ var UTIL = require('../../lib/util');
         var seed = md.digest().getBytes();
         var kp = ED25519.generateKeyPair({seed: seed});
         var signature = ED25519.sign({
-          message: new Buffer('test', 'utf8'),
+          message: Buffer.from('test', 'utf8'),
           privateKey: kp.privateKey
         });
         ASSERT.equal(eb64(signature), b64Signature);
@@ -179,7 +179,7 @@ var UTIL = require('../../lib/util');
         var seed = md.digest().getBytes();
         var kp = ED25519.generateKeyPair({seed: seed});
 
-        var signature = new Buffer(db64(b64Signature).getBytes(), 'binary');
+        var signature = Buffer.from(db64(b64Signature).getBytes(), 'binary');
 
         var verified = ED25519.verify({
           message: 'test',


### PR DESCRIPTION
removes calls on node's new Buffer. This gets rid of deprecation notices.

> (node:45127) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
