### PR TITLE
Add oid for EdDSA25519.

### DIFF
--- a/lib/oids.js
+++ b/lib/oids.js
@@ -34,6 +34,8 @@ _IN('1.2.840.113549.1.1.10', 'RSASSA-PSS');
 _IN('1.2.840.113549.1.1.11', 'sha256WithRSAEncryption');
 _IN('1.2.840.113549.1.1.12', 'sha384WithRSAEncryption');
 _IN('1.2.840.113549.1.1.13', 'sha512WithRSAEncryption');
+// Edwards-curve Digital Signature Algorithm (EdDSA) Ed25519
+_IN('1.3.101.112', 'EdDSA25519');
 
 _IN('1.2.840.10040.4.3', 'dsa-with-sha1');
 


### PR DESCRIPTION
OID data taken from: http://oid-info.com/get/1.3.101.112 and 

It's not clear to me if the id should be `Ed25519`
https://tools.ietf.org/id/draft-ietf-curdle-pkix-01.html#rfc.section.3

or `EdDSA25519`
https://tools.ietf.org/id/draft-ietf-curdle-pkix-01.html#rfc.section.5