### PR TITLE
Check for NativeBuffer in ed25519#messageToNativeBuffer

### DIFF
--- a/lib/ed25519.js
+++ b/lib/ed25519.js
@@ -147,7 +147,7 @@ ed25519.verify = function(options) {
 
 function messageToNativeBuffer(options) {
   var message = options.message;
-  if(message instanceof Uint8Array) {
+  if(message instanceof Uint8Array || message instanceof NativeBuffer) {
     return message;
   }
 


### PR DESCRIPTION
While this technically is not necessary, because node.js' Buffer
inherits from Uint8Array this contract is broken by jest.
See facebook/jest#4422.

Add a `message instanceof NativeBuffer` to the function to fix the issue,
it does no harm and *technically* would be the more correct check, because
for node.js passing a raw Uint8Array does not return a Buffer.

------

I can also adjust the function to wrap the `Uint8Array` in a `Buffer`, if `NativeBuffer === Buffer` to be super correct. Just let me know.