### PR TITLE
Ensure given IV matches block size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Forge ChangeLog
 ===============
 
+### Fixed
+- Ensure DES-CBC given IV is long enough for block size.
+
 ## 0.9.0 - 2019-09-04
 
 ### Added

--- a/tests/unit/des.js
+++ b/tests/unit/des.js
@@ -75,6 +75,20 @@ var UTIL = require('../../lib/util');
       ASSERT.equal(cipher.output.toHex(), '3a97fa79e631');
     });
 
+    // play.golang.org/p/6_MQBYzn04c
+    it('should des-ctr decrypt: foobar', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('beefdeadbeefdead'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('deadbeefdeadbeef'));
+
+      var cipher = CIPHER.createDecipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer(UTIL.hexToBytes('6df74b7b4437')));
+      cipher.finish();
+      ASSERT.equal(cipher.output.getBytes(), 'foobar');
+    });
+
     // play.golang.org/p/i892aR7YsGK
     it('should des-ctr encrypt: dead parrot', function() {
       var key = new UTIL.createBuffer(
@@ -89,6 +103,20 @@ var UTIL = require('../../lib/util');
       ASSERT.equal(cipher.output.toHex(), '389df47fa733dcf4b99b7c');
     });
 
+    // play.golang.org/p/6L0LqPS9ARt
+    it('should des-ctr decrypt: 79f1527c5737f774f85c1a9399755d895ae7', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('beefdeadbeefdead'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('deadbeefdeadbeef'));
+
+      var cipher = CIPHER.createDecipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer(UTIL.hexToBytes('79f1527c5737f774f85c1a9399755d895ae7')));
+      cipher.finish();
+      ASSERT.equal(cipher.output.getBytes(), 'riverrun, past Eve');
+    });
+
     // play.golang.org/p/WsSx6BXJniU
     it('should des-ctr encrypt: 69742773206e6f742073696c6c7920656e6f756768', function() {
       var key = new UTIL.createBuffer(
@@ -101,6 +129,20 @@ var UTIL = require('../../lib/util');
       cipher.update(UTIL.createBuffer(UTIL.hexToBytes('69742773206e6f742073696c6c7920656e6f756768')));
       cipher.finish();
       ASSERT.equal(cipher.output.toHex(), '358cb268a72dd2f2eb87615060bd3a490e85136873');
+    });
+
+    // play.golang.org/p/y01inAlMCEM
+    it('should des-ctr decrypt: 0a80bd81a4dc1303a62f', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('beefdeadbeefdead'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('deadbeefdeadbeef'));
+
+      var cipher = CIPHER.createDecipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer(UTIL.hexToBytes('0a80bd81a4dc1303a62f')));
+      cipher.finish();
+      ASSERT.equal(cipher.output.toHex(), '01189998819991197253');
     });
 
     // OpenSSL equivalent:

--- a/tests/unit/des.js
+++ b/tests/unit/des.js
@@ -61,6 +61,48 @@ var UTIL = require('../../lib/util');
       ASSERT.equal(decipher.output.getBytes(), 'foobar');
     });
 
+    // play.golang.org/p/LX_dP0cFuEt
+    it('should des-ctr encrypt: foobar', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('a1c06b381adf3651'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('818bcf76efc59662'));
+
+      var cipher = CIPHER.createCipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer('foobar'));
+      cipher.finish();
+      ASSERT.equal(cipher.output.toHex(), '3a97fa79e631');
+    });
+
+    // play.golang.org/p/i892aR7YsGK
+    it('should des-ctr encrypt: dead parrot', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('a1c06b381adf3651'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('818bcf76efc59662'));
+
+      var cipher = CIPHER.createCipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer('dead parrot'));
+      cipher.finish();
+      ASSERT.equal(cipher.output.toHex(), '389df47fa733dcf4b99b7c');
+    });
+
+    // play.golang.org/p/WsSx6BXJniU
+    it('should des-ctr encrypt: 69742773206e6f742073696c6c7920656e6f756768', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('a1c06b381adf3651'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('818bcf76efc59662'));
+
+      var cipher = CIPHER.createCipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer(UTIL.hexToBytes('69742773206e6f742073696c6c7920656e6f756768')));
+      cipher.finish();
+      ASSERT.equal(cipher.output.toHex(), '358cb268a72dd2f2eb87615060bd3a490e85136873');
+    });
+
     // OpenSSL equivalent:
     // openssl enc -des-ede3 -K a1c06b381adf36517e84575552777779da5e3d9f994b05b5 -nosalt
     it('should 3des-ecb encrypt: foobar', function() {

--- a/tests/unit/des.js
+++ b/tests/unit/des.js
@@ -31,6 +31,22 @@ var UTIL = require('../../lib/util');
       ASSERT.equal(decipher.output.getBytes(), 'foobar');
     });
 
+    it('should check des-cbc short IV', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('a1c06b381adf3651'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('818bcf76efc596'));
+
+      var error = null;
+      try {
+        var cipher = CIPHER.createCipher('DES-CBC', key);
+        cipher.start({iv: iv});
+      } catch(e) {
+        error = e;
+      }
+      ASSERT.ok(error, 'blocksize check should have failed');
+    });
+
     // OpenSSL equivalent:
     // openssl enc -des -K a1c06b381adf3651 -iv 818bcf76efc59662 -nosalt
     it('should des-cbc encrypt: foobar', function() {


### PR DESCRIPTION
#721 highlights that a bad assumption was being made with the IV size in cipherModes.js. Additionally, the given IV was not being checked against the block size to help prevent user error.

@davidlehn, I'm out of time to work on this but we still need a test (we can use the information from #721 but adjust to ensure the given IV size is proper), could you add?