### PR TITLE
Address Issue #721: Increment CTR mode counter at the correct position when blocksize is not 16

### DIFF
--- a/lib/cipherModes.js
+++ b/lib/cipherModes.js
@@ -501,7 +501,7 @@ modes.ctr.prototype.encrypt = function(input, output, finish) {
   }
 
   // block complete, increment counter (input block)
-  inc32(this._inBlock);
+  inc32(this._inBlock, this._ints - 1);
 };
 
 modes.ctr.prototype.decrypt = modes.ctr.prototype.encrypt;
@@ -599,7 +599,7 @@ modes.gcm.prototype.start = function(options) {
 
   // generate ICB (initial counter block)
   this._inBlock = this._j0.slice(0);
-  inc32(this._inBlock);
+  inc32(this._inBlock, this._ints - 1);
   this._partialBytes = 0;
 
   // consume authentication data
@@ -695,7 +695,7 @@ modes.gcm.prototype.encrypt = function(input, output, finish) {
   this._s = this.ghash(this._hashSubkey, this._s, this._outBlock);
 
   // increment counter (input block)
-  inc32(this._inBlock);
+  inc32(this._inBlock, this._ints - 1);
 };
 
 modes.gcm.prototype.decrypt = function(input, output, finish) {
@@ -709,7 +709,7 @@ modes.gcm.prototype.decrypt = function(input, output, finish) {
   this.cipher.encrypt(this._inBlock, this._outBlock);
 
   // increment counter (input block)
-  inc32(this._inBlock);
+  inc32(this._inBlock, this._ints - 1);
 
   // update hash block S
   this._hashBlock[0] = input.getInt32();
@@ -976,9 +976,9 @@ function transformIV(iv) {
   return iv;
 }
 
-function inc32(block) {
-  // increment last 32 bits of block only
-  block[block.length - 1] = (block[block.length - 1] + 1) & 0xFFFFFFFF;
+function inc32(block, pos) {
+  // increment the 32-bit number at pos
+  block[pos] = (block[pos] + 1) & 0xFFFFFFFF;
 }
 
 function from64To32(num) {

--- a/tests/unit/des.js
+++ b/tests/unit/des.js
@@ -75,6 +75,20 @@ var UTIL = require('../../lib/util');
       ASSERT.equal(cipher.output.toHex(), '3a97fa79e631');
     });
 
+    // play.golang.org/p/6_MQBYzn04c
+    it('should des-ctr decrypt: foobar', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('beefdeadbeefdead'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('deadbeefdeadbeef'));
+
+      var cipher = CIPHER.createDecipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer(UTIL.hexToBytes('6df74b7b4437')));
+      cipher.finish();
+      ASSERT.equal(cipher.output.getBytes(), 'foobar');
+    });
+
     // play.golang.org/p/i892aR7YsGK
     it('should des-ctr encrypt: dead parrot', function() {
       var key = new UTIL.createBuffer(
@@ -89,6 +103,20 @@ var UTIL = require('../../lib/util');
       ASSERT.equal(cipher.output.toHex(), '389df47fa733dcf4b99b7c');
     });
 
+    // play.golang.org/p/6L0LqPS9ARt
+    it('should des-ctr decrypt: 79f1527c5737f774f85c1a9399755d895ae7', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('beefdeadbeefdead'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('deadbeefdeadbeef'));
+
+      var cipher = CIPHER.createDecipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer(UTIL.hexToBytes('79f1527c5737f774f85c1a9399755d895ae7')));
+      cipher.finish();
+      ASSERT.equal(cipher.output.getBytes(), 'riverrun, past Eve');
+    });
+
     // play.golang.org/p/WsSx6BXJniU
     it('should des-ctr encrypt: 69742773206e6f742073696c6c7920656e6f756768', function() {
       var key = new UTIL.createBuffer(
@@ -101,6 +129,20 @@ var UTIL = require('../../lib/util');
       cipher.update(UTIL.createBuffer(UTIL.hexToBytes('69742773206e6f742073696c6c7920656e6f756768')));
       cipher.finish();
       ASSERT.equal(cipher.output.toHex(), '358cb268a72dd2f2eb87615060bd3a490e85136873');
+    });
+
+    // play.golang.org/p/y01inAlMCEM
+    it('should des-ctr decrypt: 0a80bd81a4dc1303a62f', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('beefdeadbeefdead'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('deadbeefdeadbeef'));
+
+      var cipher = CIPHER.createDecipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer(UTIL.hexToBytes('0a80bd81a4dc1303a62f')));
+      cipher.finish();
+      ASSERT.equal(cipher.output.toHex(), '01189998819991197253');
     });
 
     // OpenSSL equivalent:

--- a/tests/unit/des.js
+++ b/tests/unit/des.js
@@ -61,6 +61,48 @@ var UTIL = require('../../lib/util');
       ASSERT.equal(decipher.output.getBytes(), 'foobar');
     });
 
+    // play.golang.org/p/LX_dP0cFuEt
+    it('should des-ctr encrypt: foobar', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('a1c06b381adf3651'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('818bcf76efc59662'));
+
+      var cipher = CIPHER.createCipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer('foobar'));
+      cipher.finish();
+      ASSERT.equal(cipher.output.toHex(), '3a97fa79e631');
+    });
+
+    // play.golang.org/p/i892aR7YsGK
+    it('should des-ctr encrypt: dead parrot', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('a1c06b381adf3651'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('818bcf76efc59662'));
+
+      var cipher = CIPHER.createCipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer('dead parrot'));
+      cipher.finish();
+      ASSERT.equal(cipher.output.toHex(), '389df47fa733dcf4b99b7c');
+    });
+
+    // play.golang.org/p/WsSx6BXJniU
+    it('should des-ctr encrypt: 69742773206e6f742073696c6c7920656e6f756768', function() {
+      var key = new UTIL.createBuffer(
+        UTIL.hexToBytes('a1c06b381adf3651'));
+      var iv = new UTIL.createBuffer(
+        UTIL.hexToBytes('818bcf76efc59662'));
+
+      var cipher = CIPHER.createCipher('DES-CTR', key);
+      cipher.start({iv: iv});
+      cipher.update(UTIL.createBuffer(UTIL.hexToBytes('69742773206e6f742073696c6c7920656e6f756768')));
+      cipher.finish();
+      ASSERT.equal(cipher.output.toHex(), '358cb268a72dd2f2eb87615060bd3a490e85136873');
+    });
+
     // OpenSSL equivalent:
     // openssl enc -des-ede3 -K a1c06b381adf36517e84575552777779da5e3d9f994b05b5 -nosalt
     it('should 3des-ecb encrypt: foobar', function() {


### PR DESCRIPTION
I altered `inc32` function so that instead of incrementing the last 32 bits with respect to the buffer's length, the caller needs to provide the index of the last 32 bits depending on the blocksize of the cipher