### PR TITLE
[BUG]Remove excess padding

### DIFF
--- a/lib/cipherModes.js
+++ b/lib/cipherModes.js
@@ -70,8 +70,7 @@ modes.ecb.prototype.decrypt = function(input, output, finish) {
 modes.ecb.prototype.pad = function(input, options) {
   // add PKCS#7 padding to block (each pad byte is the
   // value of the number of pad bytes)
-  var padding = (input.length() === this.blockSize ?
-    this.blockSize : (this.blockSize - input.length()));
+  var padding = (this.blockSize - input.length());
   input.fillWithByte(padding, padding);
   return true;
 };


### PR DESCRIPTION
Remove excess padding when the length of input is just a multiple of the blocksize.
For example, when I input 128bit data with 128bit key in AES-CBC mode,the length of output should be 128bit,but the excess padding make it 256bit.
Obviously,it is a bug.