### PR TITLE
Fix: avoid prime worker message spam.

### DIFF
--- a/lib/prime.worker.js
+++ b/lib/prime.worker.js
@@ -19,8 +19,10 @@ var BIG_TWO = new BigInteger(null);
 BIG_TWO.fromInt(2);
 
 self.addEventListener('message', function(e) {
-  var result = findPrime(e.data);
-  self.postMessage(result);
+  if (e.data.hex && e.data.workLoad) {
+    var result = findPrime(e.data);
+    self.postMessage(result);
+  }
 });
 
 // start receiving ranges to check


### PR DESCRIPTION
The prime worker can receive messages posted by browser extensions (e.g. react-devtools-bridge). Since the message lacked the necessary inputs, the prime algorithm would start but never terminate. This drops useless messages on the floor.