### PR TITLE
add authenticatedAttribute signingCertificateV2

### DIFF
--- a/lib/oids.js
+++ b/lib/oids.js
@@ -65,6 +65,7 @@ _IN('1.2.840.113549.1.9.6', 'counterSignature');
 _IN('1.2.840.113549.1.9.7', 'challengePassword');
 _IN('1.2.840.113549.1.9.8', 'unstructuredAddress');
 _IN('1.2.840.113549.1.9.14', 'extensionRequest');
+_IN('1.2.840.113549.1.9.16.2.47', 'signingCertificateV2');
 
 _IN('1.2.840.113549.1.9.20', 'friendlyName');
 _IN('1.2.840.113549.1.9.21', 'localKeyId');

--- a/lib/pkcs7.js
+++ b/lib/pkcs7.js
@@ -1089,12 +1089,23 @@ function _attributeToAsn1(attr) {
         asn1.Class.UNIVERSAL, asn1.Type.GENERALIZEDTIME, false,
         asn1.dateToGeneralizedTime(date));
     }
+  } else if(attr.type === forge.pki.oids.signingCertificateV2) {
+    value = asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+        asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+          asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OCTETSTRING, false,
+            attr.value
+          )
+        ])
+      ])
+    ]);
   }
-
+  
   // TODO: expose as common API call
   // create a RelativeDistinguishedName set
   // each value in the set is an AttributeTypeAndValue first
   // containing the type (an OID) and second the value
+  
   return asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
     // AttributeType
     asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OID, false,


### PR DESCRIPTION
add the authenticatedAttribute signingCertificateV2.
where value is the sha256 hash of the entire DER Signing Certificate. Usage:
type:NodeForge.pki.oids.signingCertificateV2,
value: createHash(Buffer.from(NodeForge.pki.pemToDer(certificateToSign).getBytes(), 'binary')).toString('binary') //createHash is a generic function that receives a Buffer and return a buffer sha256 hash