### PR TITLE
Fix for issue #602. Chrome's window.crypto property is read-only, so …

### DIFF
--- a/lib/prng.js
+++ b/lib/prng.js
@@ -14,7 +14,7 @@ require('./util');
 
 var _crypto = null;
 if(forge.util.isNodejs && !forge.options.usePureJavaScript &&
-  !process.versions['node-webkit']) {
+  !process.versions['node-webkit'] && !process.versions['electron']) {
   _crypto = require('crypto');
 }
 

--- a/lib/prng.js
+++ b/lib/prng.js
@@ -14,7 +14,7 @@ require('./util');
 
 var _crypto = null;
 if(forge.util.isNodejs && !forge.options.usePureJavaScript &&
-  !process.versions['node-webkit'] && !process.versions['electron']) {
+  !process.versions['node-webkit']) {
   _crypto = require('crypto');
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -107,9 +107,8 @@ var util = module.exports = forge.util = forge.util || {};
 })();
 
 // check if running under Node.js
-util.isNodejs =
-  typeof process !== 'undefined' && process.versions && process.versions.node;
-
+util.isNodejs = typeof process !== 'undefined' &&
+  process.versions && process.versions.node && !process.versions.electron;
 
 // 'self' will also work in Web Workers (instance of WorkerGlobalScope) while
 // it will point to `window` in the main thread.


### PR DESCRIPTION
…when Electron tries to require Node's crypto library, it fails. The fix is identical to that for node-webkit.