### PR TITLE
support get info from an UTF-8 encode pem certificate

### DIFF
--- a/lib/asn1.js
+++ b/lib/asn1.js
@@ -613,6 +613,13 @@ function _fromDer(bytes, remaining, depth, options) {
         value += String.fromCharCode(bytes.getInt16());
         remaining -= 2;
       }
+    } else if (type === asn1.Type.UTF8){
+      value = '';
+      const uBytes = []
+      for (let i = 0; i < length; i ++) {
+        uBytes.push(bytes.getByte())
+      }
+      value += forge.util.utf8ByteToUnicodeStr(uBytes)
     } else {
       value = bytes.getBytes(length);
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -2998,3 +2998,65 @@ util.estimateCores = function(options, callback) {
     }, 0);
   }
 };
+
+/**
+ * utf8 byte to unicode string
+ * @param utf8Bytes
+ * @returns {string}
+ */
+util.utf8ByteToUnicodeStr = function(utf8Bytes) {
+  var unicodeStr ="";
+  for (var pos = 0; pos < utf8Bytes.length;){
+      var flag= utf8Bytes[pos];
+      var unicode = 0 ;
+      if ((flag >>> 7) === 0 ) {
+          unicodeStr+= String.fromCharCode(utf8Bytes[pos]);
+          pos += 1;
+
+      } else if ((flag & 0xFC) === 0xFC) {
+          unicode = (utf8Bytes[pos] & 0x3) << 30;
+          unicode |= (utf8Bytes[pos + 1] & 0x3F) << 24;
+          unicode |= (utf8Bytes[pos + 2] & 0x3F) << 18;
+          unicode |= (utf8Bytes[pos + 3] & 0x3F) << 12;
+          unicode |= (utf8Bytes[pos + 4] & 0x3F) << 6;
+          unicode |= (utf8Bytes[pos + 5] & 0x3F);
+          unicodeStr += String.fromCharCode(unicode) ;
+          pos += 6;
+
+      }else if ((flag & 0xF8) === 0xF8) {
+          unicode = (utf8Bytes[pos] & 0x7) << 24;
+          unicode |= (utf8Bytes[pos + 1] & 0x3F) << 18;
+          unicode |= (utf8Bytes[pos + 2] & 0x3F) << 12;
+          unicode |= (utf8Bytes[pos + 3] & 0x3F) << 6;
+          unicode |= (utf8Bytes[pos + 4] & 0x3F);
+          unicodeStr += String.fromCharCode(unicode) ;
+          pos += 5;
+
+      } else if ((flag & 0xF0) === 0xF0) {
+          unicode = (utf8Bytes[pos] & 0xF) << 18;
+          unicode |= (utf8Bytes[pos + 1] & 0x3F) << 12;
+          unicode |= (utf8Bytes[pos + 2] & 0x3F) << 6;
+          unicode |= (utf8Bytes[pos + 3] & 0x3F);
+          unicodeStr += String.fromCharCode(unicode) ;
+          pos += 4;
+
+      } else if ((flag & 0xE0) === 0xE0) {
+          unicode = (utf8Bytes[pos] & 0x1F) << 12;;
+          unicode |= (utf8Bytes[pos + 1] & 0x3F) << 6;
+          unicode |= (utf8Bytes[pos + 2] & 0x3F);
+          unicodeStr += String.fromCharCode(unicode) ;
+          pos += 3;
+
+      } else if ((flag & 0xC0) === 0xC0) { //110
+          unicode = (utf8Bytes[pos] & 0x3F) << 6;
+          unicode |= (utf8Bytes[pos+1] & 0x3F);
+          unicodeStr += String.fromCharCode(unicode) ;
+          pos += 2;
+
+      } else{
+          unicodeStr += String.fromCharCode(utf8Bytes[pos]);
+          pos += 1;
+      }
+  }
+  return unicodeStr;
+}

--- a/tests/unit/utf8-pem.js
+++ b/tests/unit/utf8-pem.js
@@ -1,0 +1,35 @@
+var PKI = require('../../lib/pki');
+
+function test() {
+  var _input = `-----BEGIN CERTIFICATE-----
+  MIID1TCCAr0CFBYvDgt6nmxPW8MkWzkF9xdoNxwUMA0GCSqGSIb3DQEBCwUAMIGl
+  MQswCQYDVQQGEwJDTjEPMA0GA1UECAwG6ZmV6KW/MQ8wDQYDVQQHDAbopb/lrokx
+  ITAfBgNVBAoMGOWNjuS4uuaKgOacr+aciemZkOWFrOWPuDEVMBMGA1UECwwM56e7
+  5Yqo6YCa5L+hMRcwFQYDVQQDDA7liJjlh68gMTE1MjE5NTEhMB8GCSqGSIb3DQEJ
+  ARYSZXhhbXBsZUBodWF3ZWkuY29tMCAXDTIwMDYwOTA1MzYyMloYDzIwNjkwOTIw
+  MDUzNjIyWjCBpTELMAkGA1UEBhMCQ04xDzANBgNVBAgMBumZleilvzEPMA0GA1UE
+  BwwG6KW/5a6JMSEwHwYDVQQKDBjljY7kuLrmioDmnK/mnInpmZDlhazlj7gxFTAT
+  BgNVBAsMDOenu+WKqOmAmuS/oTEXMBUGA1UEAwwO5YiY5YevIDExNTIxOTUxITAf
+  BgkqhkiG9w0BCQEWEmV4YW1wbGVAaHVhd2VpLmNvbTCCASIwDQYJKoZIhvcNAQEB
+  BQADggEPADCCAQoCggEBAJi6XLHZrfXqQI3DT40+Wm5JSEaphSe6dAQowVi3bbkS
+  7BqyZMumkGJ9O9nAVshcv79wbuHK/5N8IqWYMSzJUxwZAmeG6ZBK+H/7oGVXmPN1
+  jdiJPw7riymZbS1iSHuR8b/s0xGuaVV9OVa4zQPT3BeprpdnZ0PICqy/P+KMzhus
+  +MoHUyvP7WMRROYqVIv0ZGgDyvEoleuIjFgs27E5eVz2bnokVXXVfu57v++Cnhto
+  zPKN7ZOgmG8sx0T7Cm/KaVyZSFFS0dDT5YAA4L9P/p+4BM4vVC6oovvQ3qS4sa6M
+  driYJdam0tjLXAZC5vi18x9zJ/o+/yn94OXKPYZgEyECAwEAATANBgkqhkiG9w0B
+  AQsFAAOCAQEAElgDEuz8FWDVFwg+bt0kRUc6h2FKxn08VUOGNLs7dY7DP8LiVve/
+  CpUsVOpY7ePYArwg6PX+mCtKP1hxKs0R6ILrGGXUjUa3rwyv9ZSGdp6TGjzciifj
+  mQwcjLJ9/34J+0sfQbaNnKTEeo7zeVc1xLYlYvFT4M0AzM9sM6g2y0FCyS575VLK
+  17fSGMlQHWW5kO6rtvU1gxzd2LwYn6ztqNJwj/k8YWaltH3Kz+EDm7JJOfVsV35X
+  cAGlTCyA2nwff498cuSX34TKkN5FXyG1NB4cooDgTScECf7EhWmWuisdTj0a5Exz
+  Qp1PU3DlW3XU6ScsHFalaKT1ERpCKUB3Dg==
+  -----END CERTIFICATE-----`;
+
+  const msg = PKI.certificateFromPem(_input)
+  const subject = msg.subject.attributes
+    .map(attr => [attr.shortName, attr.value].join('='))
+    .join(', ')
+  console.log(subject)
+}
+
+test()


### PR DESCRIPTION
I tried to get info from a pem certificate whose Subject contains utf-8 encoded words(Chinese Simple),  and I got unreadable codes.
This is caused by the method `_fromDer()` in `/lib/ans1.js`, this method mismatch utf-8 encode words.
I hava solve this problem, at least in Chinese Simple which encoded by utf-8.
I want to make a PR, also contains some test code in `/test/unit/utf8-pem.js`, please check it, thanks very much.