### PR TITLE
Add extra condition to setPath function

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2531,6 +2531,9 @@ util.setPath = function(object, keys, value) {
     var len = keys.length;
     while(i < len) {
       var next = keys[i++];
+      if(next === '__proto__' || next === 'constructor' || next === 'prototype') {
+        return object;
+      }
       if(i == len) {
         // last
         object[next] = value;

--- a/tests/unit/util.js
+++ b/tests/unit/util.js
@@ -591,5 +591,17 @@ var UTIL = require('../../lib/util');
       var result = UTIL.text.utf16.decode(bytes);
       ASSERT.equal(result, '\ud83c\udc00');
     });
+    it('should fill object keys with specific value', function() {
+
+      var object = {};
+      UTIL.setPath(object, ['foo', 'bar'], true);
+      ASSERT.deepEqual(object, {foo: {bar: true}});
+    });
+    it('should not indirectly merge `Object` properties', function() {
+
+      var object = {};
+      UTIL.setPath(object, ['__proto__', 'polluted'], true);
+      ASSERT.deepEqual(object, {});
+    });
   });
 })();


### PR DESCRIPTION
It was possible to make prototype pollution  throught setPath function.
Now the code will exit when merging objects with sensitive properties,
such as constructor or __proto__.

See details here: 
https://snyk.io/vuln/SNYK-JS-NODEFORGE-598677