### PR TITLE
fix: globalScope is undefined when running in JSCore Environment

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -120,7 +120,7 @@ util.globalScope = (function() {
     return global;
   }
 
-  return typeof self === 'undefined' ? window : self;
+  return typeof self === 'undefined' ? window || {} : self;
 })();
 
 // define isArray


### PR DESCRIPTION
Hello,
    An issue came when I use node-forge in JSCore environment,  at lib/random.js line 119, globalScope returns undefined, cause globalScope.crypto throw Error "can't read property crypto of undefined", so I changed lib/util.js getScopeFunction to fix this problem