### PR TITLE
Feature/add unauthenticated attributes

### DIFF
--- a/lib/oids.js
+++ b/lib/oids.js
@@ -68,10 +68,10 @@ _IN('1.2.840.113549.1.9.7', 'challengePassword');
 _IN('1.2.840.113549.1.9.8', 'unstructuredAddress');
 _IN('1.2.840.113549.1.9.14', 'extensionRequest');
 
+_IN('1.2.840.113549.1.9.16.2.14', 'timeStampToken');
 _IN('1.2.840.113549.1.9.20', 'friendlyName');
 _IN('1.2.840.113549.1.9.21', 'localKeyId');
 _IN('1.2.840.113549.1.9.22.1', 'x509Certificate');
-_IN('1.2.840.113549.1.9.16.2.14', 'timeStampToken');
 
 // pkcs#12 safe bags
 _IN('1.2.840.113549.1.12.10.1.1', 'keyBag');

--- a/lib/oids.js
+++ b/lib/oids.js
@@ -71,6 +71,7 @@ _IN('1.2.840.113549.1.9.14', 'extensionRequest');
 _IN('1.2.840.113549.1.9.20', 'friendlyName');
 _IN('1.2.840.113549.1.9.21', 'localKeyId');
 _IN('1.2.840.113549.1.9.22.1', 'x509Certificate');
+_IN('1.2.840.113549.1.9.16.2.14', 'timeStampToken');
 
 // pkcs#12 safe bags
 _IN('1.2.840.113549.1.12.10.1.1', 'keyBag');

--- a/lib/pkcs7.js
+++ b/lib/pkcs7.js
@@ -245,6 +245,7 @@ p7.createSignedData = function() {
      *            (eg: forge.pki.oids.sha1).
      *          [authenticatedAttributes] an optional array of attributes
      *            to also sign along with the content.
+     *          [unauthenticatedAttributes] an optional array of unauthenticated attributes
      */
     addSigner: function(signer) {
       var issuer = signer.issuer;
@@ -322,7 +323,7 @@ p7.createSignedData = function() {
         signatureAlgorithm: forge.pki.oids.rsaEncryption,
         signature: null,
         authenticatedAttributes: authenticatedAttributes,
-        unauthenticatedAttributes: []
+        unauthenticatedAttributes: signer.unauthenticatedAttributes || []
       });
     },
 
@@ -999,7 +1000,7 @@ function _signerToAsn1(obj) {
     var attrsAsn1 = asn1.create(asn1.Class.CONTEXT_SPECIFIC, 1, true, []);
     for(var i = 0; i < obj.unauthenticatedAttributes.length; ++i) {
       var attr = obj.unauthenticatedAttributes[i];
-      attrsAsn1.values.push(_attributeToAsn1(attr));
+      attrsAsn1.value.push(_attributeToAsn1(attr));
     }
     rval.value.push(attrsAsn1);
   }

--- a/lib/pkcs7.js
+++ b/lib/pkcs7.js
@@ -245,7 +245,8 @@ p7.createSignedData = function() {
      *            (eg: forge.pki.oids.sha1).
      *          [authenticatedAttributes] an optional array of attributes
      *            to also sign along with the content.
-     *          [unauthenticatedAttributes] an optional array of unauthenticated attributes
+     *          [unauthenticatedAttributes] an optional array of unauthenticated
+     *            attributes
      */
     addSigner: function(signer) {
       var issuer = signer.issuer;


### PR DESCRIPTION
Right now is impossible to add unauthenticated attributes via the `addSigner` method. The method sets them to an empty array and ignores them later. (You can't add response from TSA for example).