### PR TITLE
Fix global check

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -115,12 +115,13 @@ util.isNodejs =
 // it will point to `window` in the main thread.
 // To remain compatible with older browsers, we fall back to 'window' if 'self'
 // is not available.
+var _globalThis = this;
 util.globalScope = (function() {
   if(util.isNodejs) {
     return global;
   }
 
-  return typeof self === 'undefined' ? window : self;
+  return typeof self === 'undefined' ? (typeof window === 'undefined' ? _globalThis : window) : self;
 })();
 
 // define isArray

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,6 +80,7 @@ outputs.forEach(info => {
   const bundle = Object.assign({}, common, {
     mode: 'development',
     output: {
+      globalObject: 'this',
       path: path.join(__dirname, 'dist'),
       filename: info.filenameBase + '.js',
       library: info.library || '[name]',
@@ -97,6 +98,7 @@ outputs.forEach(info => {
   const minify = Object.assign({}, common, {
     mode: 'production',
     output: {
+      globalObject: 'this',
       path: path.join(__dirname, 'dist'),
       filename: info.filenameBase + '.min.js',
       library: info.library || '[name]',


### PR DESCRIPTION
Current `globalScope` limit usage of a library only for node.js and browsers. It work on V8 and other JS envs, but `self === 'undefined' ? window : self` activate `window` on such environments and immediately raise runtime error. Here example of the issue: https://github.com/digitalbazaar/forge/issues/717

This patch should allow to use library not only in Node.js and Browsers envs. 

This breaking change was introduced in 0.8.0 version.