### PR TITLE
fix: fix gcm tag length truncation

### DIFF
--- a/lib/cipherModes.js
+++ b/lib/cipherModes.js
@@ -756,7 +756,7 @@ modes.gcm.prototype.afterFinish = function(output, options) {
   }
 
   // trim tag to length
-  this.tag.truncate(this.tag.length() % (this._tagLength / 8));
+  this.tag.truncate(this.tag.length() - (this._tagLength / 8));
 
   // check authentication tag
   if(options.decrypt && this.tag.bytes() !== this._tag) {


### PR DESCRIPTION
the truncate method takes the count of the number of bytes to trim off as an argument.
the calculation to calculate this number should therefore be `oldLengthInBytes - (wantedLengthInBits / 8)`

e.g. the original tag is 16 bytes long, i specify a tagLength of 32 bits, so the tag should be 4 bytes.
old calculation: `16 % (32/8) = 0` => no truncation => 16 bytes tag length
new calculation: `16  - (32/8) = 12` => truncate 12 bytes from the 16 bytes => 4 bytes tag length