### PR TITLE
Add OIDs for surname, title and givenName

### DIFF
--- a/lib/oids.js
+++ b/lib/oids.js
@@ -104,6 +104,7 @@ _IN('2.16.840.1.101.3.4.1.42', 'aes256-CBC');
 
 // certificate issuer/subject OIDs
 _IN('2.5.4.3', 'commonName');
+_IN('2.5.4.4',  'surname');
 _IN('2.5.4.5', 'serialName');
 _IN('2.5.4.6', 'countryName');
 _IN('2.5.4.7', 'localityName');
@@ -111,9 +112,11 @@ _IN('2.5.4.8', 'stateOrProvinceName');
 _IN('2.5.4.9', 'streetAddress');
 _IN('2.5.4.10', 'organizationName');
 _IN('2.5.4.11', 'organizationalUnitName');
+_IN('2.5.4.12', 'title');
 _IN('2.5.4.13', 'description');
 _IN('2.5.4.15', 'businessCategory');
 _IN('2.5.4.17', 'postalCode');
+_IN('2.5.4.42', 'givenName');
 _IN('1.3.6.1.4.1.311.60.2.1.2', 'jurisdictionOfIncorporationStateOrProvinceName');
 _IN('1.3.6.1.4.1.311.60.2.1.3', 'jurisdictionOfIncorporationCountryName');
 

--- a/lib/oids.js
+++ b/lib/oids.js
@@ -104,7 +104,7 @@ _IN('2.16.840.1.101.3.4.1.42', 'aes256-CBC');
 
 // certificate issuer/subject OIDs
 _IN('2.5.4.3', 'commonName');
-_IN('2.5.4.4',  'surname');
+_IN('2.5.4.4', 'surname');
 _IN('2.5.4.5', 'serialName');
 _IN('2.5.4.6', 'countryName');
 _IN('2.5.4.7', 'localityName');


### PR DESCRIPTION
The OIDs for surname, title and givenName were missing from the list in oids.js.

I need these OIDs to support certificates used by UZI pas cards. UZI pas is a means for Dutch healthcare professionals to identify themselves (see https://www.uziregister.nl/ and https://www.zorgcsp.nl/documents/RK1%20CPS%20UZI-register%20V10.2%20ENG.pdf). But these OIDs are very generic and probably usefull in many other cases.

This PR adds:
 - 2.5.4.4 surname
 - 2.5.4.12 title
 - 2.5.4.42 givenName