### PR TITLE
Remove link to nodeguide.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Want to contribute to forge? Great! Here are a few notes:
 Code
 ----
 
-* In general, follow the current code style or the [Node.js Style Guide][].
+* In general, follow the current code style.
 * Read the [contributing](./README.md#contributing) notes.
 * Ensure [tests pass](./README.md#testing).
 
@@ -15,5 +15,4 @@ Release Process
 
 Maintainers should refer to the [release instructions](./RELEASE.md).
 
-[Node.js Style Guide]: http://nodeguide.com/style.html
 [Semantic Versioning]: http://semver.org/


### PR DESCRIPTION
It appears nodeguide.com domain has been taken over by domain squatters and the style.html page appears to push a questionable PDF download.