### PR TITLE
fix compatibility in `usePureJavaScript` mode

### DIFF
--- a/lib/prng.js
+++ b/lib/prng.js
@@ -268,7 +268,7 @@ prng.create = function(plugin) {
     // use window.crypto.getRandomValues strong source of entropy if available
     var getRandomValues = null;
     var globalScope = forge.util.globalScope;
-    var _crypto = globalScope.crypto || globalScope.msCrypto;
+    var _crypto = globalScope !== undefined && (globalScope.crypto || globalScope.msCrypto);
     if(_crypto && _crypto.getRandomValues) {
       getRandomValues = function(arr) {
         return _crypto.getRandomValues(arr);

--- a/lib/random.js
+++ b/lib/random.js
@@ -116,7 +116,7 @@ var _ctx = spawnPrng();
 // available -- otherwise this source will be automatically used by the prng
 var getRandomValues = null;
 var globalScope = forge.util.globalScope;
-var _crypto = globalScope.crypto || globalScope.msCrypto;
+var _crypto = globalScope !== undefined && (globalScope.crypto || globalScope.msCrypto);
 if(_crypto && _crypto.getRandomValues) {
   getRandomValues = function(arr) {
     return _crypto.getRandomValues(arr);


### PR DESCRIPTION
fix compatibility in `usePureJavaScript` mode, which globalScope can be undefined