### PR TITLE
🔒 change CSR examples to use 2048 bit keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1452,7 +1452,7 @@ __Examples__
 
 ```js
 // generate a key pair
-var keys = forge.pki.rsa.generateKeyPair(1024);
+var keys = forge.pki.rsa.generateKeyPair(2048);
 
 // create a certification request (CSR)
 var csr = forge.pki.createCertificationRequest();

--- a/examples/create-cert.js
+++ b/examples/create-cert.js
@@ -1,7 +1,7 @@
 var forge = require('..');
 
-console.log('Generating 1024-bit key-pair...');
-var keys = forge.pki.rsa.generateKeyPair(1024);
+console.log('Generating 2048-bit key-pair...');
+var keys = forge.pki.rsa.generateKeyPair(2048);
 console.log('Key-pair created.');
 
 console.log('Creating self-signed certificate...');

--- a/examples/create-csr.js
+++ b/examples/create-csr.js
@@ -1,7 +1,7 @@
 var forge = require('..');
 
-console.log('Generating 1024-bit key-pair...');
-var keys = forge.pki.rsa.generateKeyPair(1024);
+console.log('Generating 2048-bit key-pair...');
+var keys = forge.pki.rsa.generateKeyPair(2048);
 console.log('Key-pair created.');
 
 console.log('Creating certification request (CSR) ...');

--- a/examples/create-pkcs12.js
+++ b/examples/create-pkcs12.js
@@ -2,8 +2,8 @@ var forge = require('..');
 
 try {
   // generate a keypair
-  console.log('Generating 1024-bit key-pair...');
-  var keys = forge.pki.rsa.generateKeyPair(1024);
+  console.log('Generating 2048-bit key-pair...');
+  var keys = forge.pki.rsa.generateKeyPair(2048);
   console.log('Key-pair created.');
 
   // create a certificate

--- a/examples/sign-p7.js
+++ b/examples/sign-p7.js
@@ -42,8 +42,8 @@ function createSigner(name) {
   console.log('Creating signer "' + name + '"...');
 
   // generate a keypair
-  console.log('Generating 1024-bit key-pair...');
-  var keys = forge.pki.rsa.generateKeyPair(1024);
+  console.log('Generating 2048-bit key-pair...');
+  var keys = forge.pki.rsa.generateKeyPair(2048);
   console.log('Key-pair created:');
   console.log(forge.pki.privateKeyToPem(keys.privateKey));
   console.log(forge.pki.publicKeyToPem(keys.publicKey));


### PR DESCRIPTION
2048 bits has been the required minimum since 2014