### PR TITLE
Fix OID `serialName` to `serialNumber`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Forge ChangeLog
 ### Added
 - OIDs for `surname`, `title`, and `givenName`.
 
+### Fixed
+- **BREAKING**: OID 2.5.4.5 name fixed from `serialName` to `serialNumber`.
+  Depending on how applications used this id to name association it could cause
+  compatibility issues.
+
 ## 0.10.0 - 2020-09-01
 
 ### Changed

--- a/lib/oids.js
+++ b/lib/oids.js
@@ -105,7 +105,7 @@ _IN('2.16.840.1.101.3.4.1.42', 'aes256-CBC');
 // certificate issuer/subject OIDs
 _IN('2.5.4.3', 'commonName');
 _IN('2.5.4.4', 'surname');
-_IN('2.5.4.5', 'serialName');
+_IN('2.5.4.5', 'serialNumber');
 _IN('2.5.4.6', 'countryName');
 _IN('2.5.4.7', 'localityName');
 _IN('2.5.4.8', 'stateOrProvinceName');


### PR DESCRIPTION
- OID 2.5.4.5 should be `serialNumber`.

@dlongley Was there a reason this id was using the wrong name?  Or was it just a typo?  What possible breakage could this cause?  Looking on the web, it seems the only places `serialName` comes up are places where people copied this code (oops!).