### PR TITLE
Use plain email.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 ## Reporting a Vulnerability
 
-Please report security issues to `security@digitalbazaar.com`
+Please report security issues to security@digitalbazaar.com.


### PR DESCRIPTION
Plain email will let markdown render as a mailto link.