### PR TITLE
Fix double call of String.fromCharCode

### DIFF
--- a/lib/prng.js
+++ b/lib/prng.js
@@ -317,7 +317,7 @@ prng.create = function(plugin) {
           // throw in more pseudo random
           next = seed >>> (i << 3);
           next ^= Math.floor(Math.random() * 0x0100);
-          b.putByte(String.fromCharCode(next & 0xFF));
+          b.putByte(next & 0xFF);
         }
       }
     }


### PR DESCRIPTION
This fixes a bug in the PRNG. There is a double call to `String.fromCharCode`: one [in prng.js](https://github.com/digitalbazaar/forge/blob/c90cd85104e9167703e7a25f6b88e7febc9aa35a/lib/prng.js#L320) and one in [`putByte`](https://github.com/digitalbazaar/forge/blob/c90cd85104e9167703e7a25f6b88e7febc9aa35a/lib/util.js#L251). It causes 97% of the bytes to become zero. This caused a [vulnerability in keypair](https://github.com/juliangruber/keypair/security/advisories/GHSA-3f99-hvg4-qjwj), which was just published. However, I do not believe it is a vulnerability in forge, because this PRNG code is no longer used for generating crypto keys. (I think this code is essentially dead code in forge now.) That's why I am posting this as a regular pull request.