### PR TITLE
Fix Invalid base64 length when encode base64

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1584,9 +1584,9 @@ util.encode64 = function(input, maxline) {
   var chr1, chr2, chr3;
   var i = 0;
   while(i < input.length) {
-    chr1 = input.charCodeAt(i++);
-    chr2 = input.charCodeAt(i++);
-    chr3 = input.charCodeAt(i++);
+    chr1 = input.charCodeAt(i++) & 0xff;
+    chr2 = input.charCodeAt(i++) & 0xff;
+    chr3 = input.charCodeAt(i++) & 0xff;
 
     // encode 4 character group
     line += _base64.charAt(chr1 >> 2);
@@ -1774,9 +1774,9 @@ util.binary.base64.encode = function(input, maxline) {
   var chr1, chr2, chr3;
   var i = 0;
   while(i < input.byteLength) {
-    chr1 = input[i++];
-    chr2 = input[i++];
-    chr3 = input[i++];
+    chr1 = input[i++] & 0xff;
+    chr2 = input[i++] & 0xff;
+    chr3 = input[i++] & 0xff;
 
     // encode 4 character group
     line += _base64.charAt(chr1 >> 2);


### PR DESCRIPTION
When using the base64 encoding function, it is often the case that the digitized string is too short to be divisible by 4. This is because some numbers using charCodeAt are too large and fall outside the range of 64 by substituting none in place of the code. The situation is improved by adding alignment to byte.

util.binary.base64.encode = function(input, maxline) {
  var line = '';
  var output = '';
  var chr1, chr2, chr3;
  var i = 0;
  while(i < input.byteLength) {
    chr1 = input[i++] & 0xff;
    chr2 = input[i++] & 0xff;
    chr3 = input[i++] & 0xff;

util.encode64 = function(input, maxline) {
  // TODO: deprecate: "Deprecated. Use util.binary.base64.encode instead."
  var line = '';
  var output = '';
  var chr1, chr2, chr3;
  var i = 0;
  while(i < input.length) {
    chr1 = input.charCodeAt(i++) & 0xff;
    chr2 = input.charCodeAt(i++) & 0xff;
    chr3 = input.charCodeAt(i++) & 0xff;
