### PR TITLE
Update docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.py[co]
 *.sw[nop]
 *~
-.bower.json
 .cdtproject
 .classpath
 .cproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 Forge ChangeLog
 ===============
 
-## 0.11.0 - 2021-xx-xx
+## 1.0.0 - 2022-xx-xx
+
+### Notes
+- **1.0.0**!
+- This project is over a decade old! Time for a 1.0.0 release.
+- The URL related changes may expose bugs in some of the networking related
+  code (unrelated to the much wider used cryptography code). The automated and
+  manual test coverage for this code is weak at best. Issues or patches to
+  update the code or tests would be appreciated.
 
 ### Removed
 - **SECURITY**, **BREAKING**: Remove `forge.debug` API. The API has the
@@ -27,6 +35,12 @@ Forge ChangeLog
 
 ### Changed
 - **BREAKING**: Increase supported Node.js version to 6.13.0 for URL support.
+- **BREAKING**: Renamed `master` branch to `main`.
+- **BREAKING**: Release process updated to use tooling that prefixes versions
+  with `v`. Other tools, scripts, or scanners may need to adapt.
+- **BREAKING**: Remove docs related to Bower and
+  [forge-dist](https://github.com/digitalbazaar/forge-dist). Use [NPM][] or
+  another CDN. (Also be sure to read "Security Considerations" in the README.)
 
 ### Added
 - OIDs for `surname`, `title`, and `givenName`.
@@ -35,12 +49,6 @@ Forge ChangeLog
 - **BREAKING**: OID 2.5.4.5 name fixed from `serialName` to `serialNumber`.
   Depending on how applications used this id to name association it could cause
   compatibility issues.
-
-### Notes
-- The URL related changes may expose bugs in some of the networking related
-  code (unrelated to the much wider used cryptography code). The automated and
-  manual test coverage for this code is weak at best. Issues or patches to
-  update the code or tests would be appreciated.
 
 ## 0.10.0 - 2020-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@ Forge ChangeLog
 - **BREAKING**: Release process updated to use tooling that prefixes versions
   with `v`. Other tools, scripts, or scanners may need to adapt.
 - **BREAKING**: Remove docs related to Bower and
-  [forge-dist](https://github.com/digitalbazaar/forge-dist). Use [NPM][] or
-  another CDN. (Also be sure to read "Security Considerations" in the README.)
+  [forge-dist](https://github.com/digitalbazaar/forge-dist). Install using
+  [another method](./README.md#installation).
 
 ### Added
 - OIDs for `surname`, `title`, and `givenName`.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ not be regularly updated.
 
 If you want to use forge with [Node.js][], it is available through `npm`:
 
-https://npmjs.org/package/node-forge
+https://www.npmjs.com/package/node-forge
 
 Installation:
 
@@ -120,24 +120,12 @@ var forge = require('node-forge');
 The npm package includes pre-built `forge.min.js`, `forge.all.min.js`, and
 `prime.worker.min.js` using the [UMD][] format.
 
-### Bundle / Bower
-
-Each release is published in a separate repository as pre-built and minimized
-basic forge bundles using the [UMD][] format.
-
-https://github.com/digitalbazaar/forge-dist
-
-This bundle can be used in many environments. In particular it can be installed
-with [Bower][]:
-
-    bower install forge
-
 ### jsDelivr CDN
 
 To use it via [jsDelivr](https://www.jsdelivr.com/package/npm/node-forge) include this in your html:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/node-forge@0.7.0/dist/forge.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/node-forge@1.0.0/dist/forge.min.js"></script>
 ```
 
 ### unpkg CDN
@@ -145,7 +133,7 @@ To use it via [jsDelivr](https://www.jsdelivr.com/package/npm/node-forge) includ
 To use it via [unpkg](https://unpkg.com/#/) include this in your html:
 
 ```html
-<script src="https://unpkg.com/node-forge@0.7.0/dist/forge.min.js"></script>
+<script src="https://unpkg.com/node-forge@1.0.0/dist/forge.min.js"></script>
 ```
 
 ### Development Requirements
@@ -2003,8 +1991,8 @@ When using this code please keep the following in mind:
   runtime characteristics, runtime optimization, code optimization, code
   minimization, code obfuscation, bundling tools, possible bugs, the Forge code
   itself, and so on.
-- If using pre-built bundles from [Bower][] or similar be aware someone else
-  ran the tools to create those files.
+- If using pre-built bundles from [NPM][], another CDN, or similar, be aware
+  someone else ran the tools to create those files.
 - Use a secure transport channel such as [TLS][] to load scripts and consider
   using additional security mechanisms such as [Subresource Integrity][] script
   attributes.
@@ -2030,7 +2018,8 @@ Contact
 * Code: https://github.com/digitalbazaar/forge
 * Bugs: https://github.com/digitalbazaar/forge/issues
 * Email: support@digitalbazaar.com
-* IRC: [#forgejs][] on [freenode][]
+* IRC: [#forgejs][] on [Libera.Chat][] (people may also be on [freenode][] for
+  historical reasons).
 
 Donations
 ---------
@@ -2045,7 +2034,6 @@ Financial support is welcome and helps contribute to futher development:
 [3DES]: https://en.wikipedia.org/wiki/Triple_DES
 [AES]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
 [ASN.1]: https://en.wikipedia.org/wiki/ASN.1
-[Bower]: https://bower.io/
 [Browserify]: http://browserify.org/
 [CBC]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation
 [CFB]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation
@@ -2058,7 +2046,9 @@ Financial support is welcome and helps contribute to futher development:
 [HMAC]: https://en.wikipedia.org/wiki/HMAC
 [JavaScript]: https://en.wikipedia.org/wiki/JavaScript
 [Karma]: https://karma-runner.github.io/
+[Libera.Chat]: https://libera.chat/
 [MD5]: https://en.wikipedia.org/wiki/MD5
+[NPM]: https://www.npmjs.com/
 [Node.js]: https://nodejs.org/
 [OFB]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation
 [PKCS#10]: https://en.wikipedia.org/wiki/Certificate_signing_request

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,77 +1,19 @@
 Forge Release Process
 =====================
 
-Versioning
-----------
+Prepare a Release
+-----------------
 
 * Follow the [Semantic Versioning][] guidelines.
-* Use version X.Y.Z-dev in dev mode.
-* Use version X.Y.Z for releases.
-
-Master Branch Release Process
------------------------------
-
 * Ensure [tests pass](./README.md#testing).
+* Ensure [CHANGELOG.md](./CHANGELOG.md) is up-to-date using [Keep a
+  CHANGELOG][] style.
 
-## Update the main repository:
+Publish to NPM
+--------------
 
-* Commit changes.
-* Update the [CHANGELOG](./CHANGELOG.md) as needed using rougly
-  [Keep a CHANGELOG][] style.
-* `$EDITOR package.json`: update to release version and remove `-dev` suffix.
-* `git commit package.json -m "Release {version}."`
-* `git tag {version}`
-* `$EDITOR package.json`: update to next version and add `-dev` suffix.
-* `git commit package.json -m "Start {next-version}."`
-* `git push`
-* `git push --tags`
+As of Forge 1.0.0 publishing is performed using the `pubnpm` script from
+https://github.com/digitalbazaar/publish-script.
 
-## Publish to NPM:
-
-To ensure a clean upload, use a clean updated checkout, and run the following:
-
-* `git checkout {version}`
-* `npm install`
-* `npm publish`
-
-## Update bundled distribution
-
-This is kept in a different repository to avoid the accumulated size when
-adding per-release bundles.
-
-* Checkout [forge-dist][].
-* Build a clean Forge version you want to distribute:
-  * `git checkout {version}`
-  * `npm install`
-  * `npm run build`
-* Copy files to `forge-dist`:
-  * `cp dist/forge.min.js{,.map} dist/prime.worker.min.js{,.map} FORGEDIST/dist/`
-* Release `forge-dist`:
-  * `git commit -a -m "Release {version}."`
-  * `git tag {version}`
-  * `git push`
-  * `git push origin {version}`
-
-Older Branch Release Process
-----------------------------
-
-In order to provide support for Bower (and similar) for current built bundle
-releases and historical releases the [forge-dist][] repository needs to be
-updated with code changes and tags from the main repository. Once a historical
-branch, like 0.6.x, on the main repository is updated and tagged, do the
-following:
-
-* Checkout [forge-dist][].
-* Setup an upstream branch:
-  * `git remote add upstream git@github.com:digitalbazaar/forge.git`
-  * `git fetch upstream`
-* Merge changes:
-  * `git checkout 0.6.x`
-  * `git merge upstream/0.6.x`
-* Push code and tag(s):
-  * `git push`
-  * `git push origin {version}`
-
-[Keep a CHANGELOG]: http://keepachangelog.com/
-[Semantic Versioning]: http://semver.org/
-[forge-dist]: https://github.com/digitalbazaar/forge-dist
+[Keep a CHANGELOG]: https://keepachangelog.com/
+[Semantic Versioning]: https://semver.org/


### PR DESCRIPTION
- Update to v1.0.0.
- Update changelog.
- Update release details.
- Remove mentions of bower and forge-dist.
- Rename master to main.
- Add Libera.Chat IRC channel.
- Minor other fixes.