### PR TITLE
Add type to prime and prime.worker messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Forge ChangeLog
 ### Fixed
 - [x509] 'Expected' and 'Actual' issuers were backwards in verification failure
   message.
+- [prime,prime.worker] Add type to messages and ignore unexpected messages.
 
 ### Added
 - [oid,x509]: Added OID `1.3.14.3.2.29 / sha1WithRSASignature` for sha1 with

--- a/lib/prime.js
+++ b/lib/prime.js
@@ -219,6 +219,11 @@ function primeincFindPrimeWithWorkers(bits, rng, options, callback) {
         return;
       }
 
+      // ignore other messages
+      if(e.data.type !== 'forge.prime.worker.find.response') {
+        return;
+      }
+
       --running;
       var data = e.data;
       if(data.found) {
@@ -240,6 +245,7 @@ function primeincFindPrimeWithWorkers(bits, rng, options, callback) {
 
       // start prime search
       e.target.postMessage({
+        type: 'forge.prime.worker.find.request',
         hex: hex,
         workLoad: workLoad
       });

--- a/lib/prime.worker.js
+++ b/lib/prime.worker.js
@@ -19,12 +19,18 @@ var BIG_TWO = new BigInteger(null);
 BIG_TWO.fromInt(2);
 
 self.addEventListener('message', function(e) {
+  if(e.data.type !== 'forge.prime.worker.find.request') {
+    return;
+  }
   var result = findPrime(e.data);
   self.postMessage(result);
 });
 
 // start receiving ranges to check
-self.postMessage({found: false});
+self.postMessage({
+  type: 'forge.prime.worker.find.response',
+  found: false
+});
 
 // primes are 30k+i for i = 1, 7, 11, 13, 17, 19, 23, 29
 var GCD_30_DELTA = [6, 4, 2, 4, 2, 4, 6, 2];
@@ -46,13 +52,20 @@ function findPrime(data) {
   for(var i = 0; i < workLoad; ++i) {
     // do primality test
     if(isProbablePrime(num)) {
-      return {found: true, prime: num.toString(16)};
+      return {
+        type: 'forge.prime.worker.find.response',
+        found: true,
+        prime: num.toString(16)
+      };
     }
     // get next potential prime
     num.dAddOffset(GCD_30_DELTA[deltaIdx++ % 8], 0);
   }
 
-  return {found: false};
+  return {
+    type: 'forge.prime.worker.find.response',
+    found: false
+  };
 }
 
 function isProbablePrime(n) {


### PR DESCRIPTION
- Add type to prime and prime.worker messages.
- Ignore unexpected messages.

I'm not sure how necessary this is, and it seems verbose.  But it will likely fix https://github.com/digitalbazaar/forge/pull/764 in a more robust way.  It could be optimized, but it's probably fine.