### PR TITLE
fix: Replace deprecated String.prototype.substr()

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ var index = 0;
 var decrypted = '';
 do {
   decrypted += decipher.output.getBytes();
-  var buf = forge.util.createBuffer(encryptedBytes.substr(index, chunkSize));
+  var buf = forge.util.createBuffer(encryptedBytes.slice(index, index + chunkSize));
   decipher.update(buf);
   index += chunkSize;
 } while(index < length);

--- a/lib/asn1.js
+++ b/lib/asn1.js
@@ -689,7 +689,7 @@ asn1.toDer = function(obj) {
         // leading 0xFF for negative integer
         (obj.value.charCodeAt(0) === 0xFF &&
         (obj.value.charCodeAt(1) & 0x80) === 0x80))) {
-        value.putBytes(obj.value.substr(1));
+        value.putBytes(obj.value.slice(1));
       } else {
         value.putBytes(obj.value);
       }
@@ -851,12 +851,12 @@ asn1.utcTimeToDate = function(utc) {
   var date = new Date();
 
   // if YY >= 50 use 19xx, if YY < 50 use 20xx
-  var year = parseInt(utc.substr(0, 2), 10);
+  var year = parseInt(utc.slice(0, 2), 10);
   year = (year >= 50) ? 1900 + year : 2000 + year;
-  var MM = parseInt(utc.substr(2, 2), 10) - 1; // use 0-11 for month
-  var DD = parseInt(utc.substr(4, 2), 10);
-  var hh = parseInt(utc.substr(6, 2), 10);
-  var mm = parseInt(utc.substr(8, 2), 10);
+  var MM = parseInt(utc.slice(2, 4), 10) - 1; // use 0-11 for month
+  var DD = parseInt(utc.slice(4, 6), 10);
+  var hh = parseInt(utc.slice(6, 8), 10);
+  var mm = parseInt(utc.slice(8, 10), 10);
   var ss = 0;
 
   // not just YYMMDDhhmmZ
@@ -868,7 +868,7 @@ asn1.utcTimeToDate = function(utc) {
     // see if seconds are present
     if(c !== '+' && c !== '-') {
       // get seconds
-      ss = parseInt(utc.substr(10, 2), 10);
+      ss = parseInt(utc.slice(10, 12), 10);
       end += 2;
     }
   }
@@ -882,8 +882,8 @@ asn1.utcTimeToDate = function(utc) {
     c = utc.charAt(end);
     if(c === '+' || c === '-') {
       // get hours+minutes offset
-      var hhoffset = parseInt(utc.substr(end + 1, 2), 10);
-      var mmoffset = parseInt(utc.substr(end + 4, 2), 10);
+      var hhoffset = parseInt(utc.slice(end + 1, end + 3), 10);
+      var mmoffset = parseInt(utc.slice(end + 4, end + 6), 10);
 
       // calculate offset in milliseconds
       var offset = hhoffset * 60 + mmoffset;
@@ -935,12 +935,12 @@ asn1.generalizedTimeToDate = function(gentime) {
     mm' is the absolute value of the offset from GMT in minutes */
   var date = new Date();
 
-  var YYYY = parseInt(gentime.substr(0, 4), 10);
-  var MM = parseInt(gentime.substr(4, 2), 10) - 1; // use 0-11 for month
-  var DD = parseInt(gentime.substr(6, 2), 10);
-  var hh = parseInt(gentime.substr(8, 2), 10);
-  var mm = parseInt(gentime.substr(10, 2), 10);
-  var ss = parseInt(gentime.substr(12, 2), 10);
+  var YYYY = parseInt(gentime.slice(0, 4), 10);
+  var MM = parseInt(gentime.slice(4, 6), 10) - 1; // use 0-11 for month
+  var DD = parseInt(gentime.slice(6, 8), 10);
+  var hh = parseInt(gentime.slice(8, 10), 10);
+  var mm = parseInt(gentime.slice(10, 12), 10);
+  var ss = parseInt(gentime.slice(12, 14), 10);
   var fff = 0;
   var offset = 0;
   var isUTC = false;
@@ -952,8 +952,8 @@ asn1.generalizedTimeToDate = function(gentime) {
   var end = gentime.length - 5, c = gentime.charAt(end);
   if(c === '+' || c === '-') {
     // get hours+minutes offset
-    var hhoffset = parseInt(gentime.substr(end + 1, 2), 10);
-    var mmoffset = parseInt(gentime.substr(end + 4, 2), 10);
+    var hhoffset = parseInt(gentime.slice(end + 1, end + 3), 10);
+    var mmoffset = parseInt(gentime.slice(end + 4, end + 6), 10);
 
     // calculate offset in milliseconds
     offset = hhoffset * 60 + mmoffset;
@@ -969,7 +969,7 @@ asn1.generalizedTimeToDate = function(gentime) {
 
   // check for second fraction
   if(gentime.charAt(14) === '.') {
-    fff = parseFloat(gentime.substr(14), 10) * 1000;
+    fff = parseFloat(gentime.slice(14), 10) * 1000;
   }
 
   if(isUTC) {
@@ -1007,7 +1007,7 @@ asn1.dateToUtcTime = function(date) {
 
   // create format YYMMDDhhmmssZ
   var format = [];
-  format.push(('' + date.getUTCFullYear()).substr(2));
+  format.push(('' + date.getUTCFullYear()).slice(2));
   format.push('' + (date.getUTCMonth() + 1));
   format.push('' + date.getUTCDate());
   format.push('' + date.getUTCHours());

--- a/lib/jsbn.js
+++ b/lib/jsbn.js
@@ -655,7 +655,7 @@ var a = Math.pow(b,cs);
 var d = nbv(a), y = nbi(), z = nbi(), r = "";
 this.divRemTo(d,y,z);
 while(y.signum() > 0) {
- r = (a+z.intValue()).toString(b).substr(1) + r;
+ r = (a+z.intValue()).toString(b).slice(1) + r;
  y.divRemTo(d,y,z);
 }
 return z.intValue().toString(b) + r;

--- a/lib/md5.js
+++ b/lib/md5.js
@@ -150,7 +150,7 @@ md5.create = function() {
     // _padding starts with 1 byte with first bit is set (byte value 128), then
     // there may be up to (blockSize - 1) other pad bytes
     var overflow = remaining & (md.blockLength - 1);
-    finalBlock.putBytes(_padding.substr(0, md.blockLength - overflow));
+    finalBlock.putBytes(_padding.slice(0, md.blockLength - overflow));
 
     // serialize message length in bits in little-endian order; since length
     // is stored in bytes we multiply by 8 and add carry

--- a/lib/pbe.js
+++ b/lib/pbe.js
@@ -505,7 +505,7 @@ pki.encryptRsaPrivateKey = function(rsaKey, password, options) {
   }
 
   // encrypt private key using OpenSSL legacy key derivation
-  var dk = forge.pbe.opensslDeriveBytes(password, iv.substr(0, 8), dkLen);
+  var dk = forge.pbe.opensslDeriveBytes(password, iv.slice(0, 8), dkLen);
   var cipher = cipherFn(dk);
   cipher.start(iv);
   cipher.update(asn1.toDer(pki.privateKeyToAsn1(rsaKey)));
@@ -599,7 +599,7 @@ pki.decryptRsaPrivateKey = function(pem, password) {
 
     // use OpenSSL legacy key derivation
     var iv = forge.util.hexToBytes(msg.dekInfo.parameters);
-    var dk = forge.pbe.opensslDeriveBytes(password, iv.substr(0, 8), dkLen);
+    var dk = forge.pbe.opensslDeriveBytes(password, iv.slice(0, 8), dkLen);
     var cipher = cipherFn(dk);
     cipher.start(iv);
     cipher.update(forge.util.createBuffer(msg.body));
@@ -944,7 +944,7 @@ pki.pbe.opensslDeriveBytes = function(password, salt, dkLen, md) {
   for(var length = 16, i = 1; length < dkLen; ++i, length += 16) {
     digests.push(hash(md, digests[i - 1] + password + salt));
   }
-  return digests.join('').substr(0, dkLen);
+  return digests.join('').slice(0, dkLen);
 };
 
 function hash(md, bytes) {
@@ -979,7 +979,7 @@ function prfAlgorithmToMessageDigest(prfAlgorithm) {
   case 'hmacWithSHA256':
   case 'hmacWithSHA384':
   case 'hmacWithSHA512':
-    prfAlgorithm = prfAlgorithm.substr(8).toLowerCase();
+    prfAlgorithm = prfAlgorithm.slice(8).toLowerCase();
     break;
   default:
     var error = new Error('Unsupported PRF algorithm.');

--- a/lib/pbkdf2.js
+++ b/lib/pbkdf2.js
@@ -160,7 +160,7 @@ module.exports = forge.pbkdf2 = pkcs5.pbkdf2 = function(
         produce a derived key DK:
 
         DK = T_1 || T_2 ||  ...  || T_len<0..r-1> */
-      dk += (i < len) ? xor : xor.substr(0, r);
+      dk += (i < len) ? xor : xor.substring(0, r);
     }
     /* 5. Output the derived key DK. */
     return dk;
@@ -201,7 +201,7 @@ module.exports = forge.pbkdf2 = pkcs5.pbkdf2 = function(
       produce a derived key DK:
 
       DK = T_1 || T_2 ||  ...  || T_len<0..r-1> */
-    dk += (i < len) ? xor : xor.substr(0, r);
+    dk += (i < len) ? xor : xor.substring(0, r);
 
     ++i;
     outer();

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -216,10 +216,10 @@ function foldHeader(header) {
       var insert = rval[candidate];
       if(insert === ',') {
         ++candidate;
-        rval = rval.substr(0, candidate) + '\r\n ' + rval.substr(candidate);
+        rval = rval.slice(0, candidate) + '\r\n ' + rval.slice(candidate);
       } else {
-        rval = rval.substr(0, candidate) +
-          '\r\n' + insert + rval.substr(candidate + 1);
+        rval = rval.slice(0, candidate) +
+          '\r\n' + insert + rval.slice(candidate + 1);
       }
       length = (i - candidate - 1);
       candidate = -1;

--- a/lib/prng.js
+++ b/lib/prng.js
@@ -359,7 +359,7 @@ prng.create = function(plugin) {
     // iterate over pools distributing entropy cyclically
     var count = bytes.length;
     for(var i = 0; i < count; ++i) {
-      ctx.pools[ctx.pool].update(bytes.substr(i, 1));
+      ctx.pools[ctx.pool].update(bytes.slice(i, i + 1));
       ctx.pool = (ctx.pool === 31) ? 0 : ctx.pool + 1;
     }
   };

--- a/lib/pss.js
+++ b/lib/pss.js
@@ -137,7 +137,7 @@ pss.create = function(options) {
      *     maskedDB to zero. */
     var mask = (0xFF00 >> (8 * emLen - emBits)) & 0xFF;
     maskedDB = String.fromCharCode(maskedDB.charCodeAt(0) & ~mask) +
-      maskedDB.substr(1);
+      maskedDB.slice(1);
 
     /* 12. Let EM = maskedDB || H || 0xbc.
      * 13. Output EM. */
@@ -165,7 +165,7 @@ pss.create = function(options) {
     /* c. Convert the message representative m to an encoded message EM
      *    of length emLen = ceil((modBits - 1) / 8) octets, where modBits
      *    is the length in bits of the RSA modulus n */
-    em = em.substr(-emLen);
+    em = em.slice(-emLen);
 
     /* 3. If emLen < hLen + sLen + 2, output "inconsistent" and stop. */
     if(emLen < hLen + sLen + 2) {
@@ -181,8 +181,8 @@ pss.create = function(options) {
     /* 5. Let maskedDB be the leftmost emLen - hLen - 1 octets of EM, and
      *    let H be the next hLen octets. */
     var maskLen = emLen - hLen - 1;
-    var maskedDB = em.substr(0, maskLen);
-    var h = em.substr(maskLen, hLen);
+    var maskedDB = em.slice(0, maskLen);
+    var h = em.slice(maskLen, maskLen + hLen);
 
     /* 6. If the leftmost 8emLen - emBits bits of the leftmost octet in
      *    maskedDB are not all equal to zero, output "inconsistent" and stop. */
@@ -202,7 +202,7 @@ pss.create = function(options) {
 
     /* 9. Set the leftmost 8emLen - emBits bits of the leftmost octet
      * in DB to zero. */
-    db = String.fromCharCode(db.charCodeAt(0) & ~mask) + db.substr(1);
+    db = String.fromCharCode(db.charCodeAt(0) & ~mask) + db.slice(1);
 
     /* 10. If the emLen - hLen - sLen - 2 leftmost octets of DB are not zero
      * or if the octet at position emLen - hLen - sLen - 1 (the leftmost
@@ -220,7 +220,7 @@ pss.create = function(options) {
     }
 
     /* 11. Let salt be the last sLen octets of DB. */
-    var salt = db.substr(-sLen);
+    var salt = db.slice(-sLen);
 
     /* 12.  Let M' = (0x)00 00 00 00 00 00 00 00 || mHash || salt */
     var m_ = new forge.util.ByteBuffer();

--- a/lib/rsa.js
+++ b/lib/rsa.js
@@ -1748,7 +1748,7 @@ function _bnToBytes(b) {
     // leading 0xFF for negative integer
     (bytes.charCodeAt(0) === 0xFF &&
     (bytes.charCodeAt(1) & 0x80) === 0x80))) {
-    return bytes.substr(1);
+    return bytes.slice(1);
   }
   return bytes;
 }

--- a/lib/sha1.js
+++ b/lib/sha1.js
@@ -151,7 +151,7 @@ sha1.create = function() {
     // _padding starts with 1 byte with first bit is set (byte value 128), then
     // there may be up to (blockSize - 1) other pad bytes
     var overflow = remaining & (md.blockLength - 1);
-    finalBlock.putBytes(_padding.substr(0, md.blockLength - overflow));
+    finalBlock.putBytes(_padding.slice(0, md.blockLength - overflow));
 
     // serialize message length in bits in big-endian order; since length
     // is stored in bytes we multiply by 8 and add carry from next int

--- a/lib/sha256.js
+++ b/lib/sha256.js
@@ -156,7 +156,7 @@ sha256.create = function() {
     // _padding starts with 1 byte with first bit is set (byte value 128), then
     // there may be up to (blockSize - 1) other pad bytes
     var overflow = remaining & (md.blockLength - 1);
-    finalBlock.putBytes(_padding.substr(0, md.blockLength - overflow));
+    finalBlock.putBytes(_padding.slice(0, md.blockLength - overflow));
 
     // serialize message length in bits in big-endian order; since length
     // is stored in bytes we multiply by 8 and add carry from next int

--- a/lib/sha512.js
+++ b/lib/sha512.js
@@ -210,7 +210,7 @@ sha512.create = function(algorithm) {
     // _padding starts with 1 byte with first bit is set (byte value 128), then
     // there may be up to (blockSize - 1) other pad bytes
     var overflow = remaining & (md.blockLength - 1);
-    finalBlock.putBytes(_padding.substr(0, md.blockLength - overflow));
+    finalBlock.putBytes(_padding.slice(0, md.blockLength - overflow));
 
     // serialize message length in bits in big-endian order; since length
     // is stored in bytes we multiply by 8 and add carry from next int

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -296,8 +296,8 @@ var prf_TLS1 = function(secret, label, seed, length) {
     two secrets is half of the secret rounded up. */
   var idx = (secret.length >> 1);
   var slen = idx + (secret.length & 1);
-  var s1 = secret.substr(0, slen);
-  var s2 = secret.substr(idx, slen);
+  var s1 = secret.slice(0, slen);
+  var s2 = secret.slice(idx, idx + slen);
   var ai = forge.util.createBuffer();
   var hmac = forge.hmac.create();
   seed = label + seed;

--- a/lib/util.js
+++ b/lib/util.js
@@ -209,15 +209,15 @@ util.ByteStringBuffer = ByteStringBuffer;
   string is constructed by concatenating 4 bytes together at a time, the
   memory usage will be ~44MB; so ~22x increase. The strings are only joined
   together when an operation requiring their joining takes place, such as
-  substr(). This function is called when adding data to this buffer to ensure
+  slice(). This function is called when adding data to this buffer to ensure
   these types of strings are periodically joined to reduce the memory
   footprint. */
 var _MAX_CONSTRUCTED_STRING_LENGTH = 4096;
 util.ByteStringBuffer.prototype._optimizeConstructedString = function(x) {
   this._constructedStringLength += x;
   if(this._constructedStringLength > _MAX_CONSTRUCTED_STRING_LENGTH) {
-    // this substr() should cause the constructed string to join
-    this.data.substr(0, 1);
+    // this slice() should cause the constructed string to join
+    this.data.slice(0, 1);
     this._constructedStringLength = 0;
   }
 };
@@ -626,9 +626,9 @@ util.ByteStringBuffer.prototype.at = function(i) {
  * @return this buffer.
  */
 util.ByteStringBuffer.prototype.setAt = function(i, b) {
-  this.data = this.data.substr(0, this.read + i) +
+  this.data = this.data.slice(0, this.read + i) +
     String.fromCharCode(b) +
-    this.data.substr(this.read + i + 1);
+    this.data.slice(this.read + i + 1);
   return this;
 };
 
@@ -685,7 +685,7 @@ util.ByteStringBuffer.prototype.clear = function() {
  */
 util.ByteStringBuffer.prototype.truncate = function(count) {
   var len = Math.max(0, this.length() - count);
-  this.data = this.data.substr(this.read, len);
+  this.data = this.data.slice(this.read, this.read + len);
   this.read = 0;
   return this;
 };
@@ -1500,7 +1500,7 @@ util.hexToBytes = function(hex) {
   }
   // convert 2 characters (1 byte) at a time
   for(; i < hex.length; i += 2) {
-    rval += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
+    rval += String.fromCharCode(parseInt(hex.slice(i, i + 2), 16));
   }
   return rval;
 };
@@ -1599,8 +1599,8 @@ util.encode64 = function(input, maxline) {
     }
 
     if(maxline && line.length > maxline) {
-      output += line.substr(0, maxline) + '\r\n';
-      line = line.substr(maxline);
+      output += line.slice(0, maxline) + '\r\n';
+      line = line.slice(maxline);
     }
   }
   output += line;
@@ -1754,7 +1754,7 @@ util.binary.hex.decode = function(hex, output, offset) {
   }
   // convert 2 characters (1 byte) at a time
   for(; i < hex.length; i += 2) {
-    out[j++] = parseInt(hex.substr(i, 2), 16);
+    out[j++] = parseInt(hex.slice(i, i + 2), 16);
   }
   return output ? (j - offset) : out;
 };
@@ -1789,8 +1789,8 @@ util.binary.base64.encode = function(input, maxline) {
     }
 
     if(maxline && line.length > maxline) {
-      output += line.substr(0, maxline) + '\r\n';
-      line = line.substr(maxline);
+      output += line.slice(0, maxline) + '\r\n';
+      line = line.slice(maxline);
     }
   }
   output += line;
@@ -2353,8 +2353,8 @@ util.formatNumber = function(number, decimals, dec_point, thousands_sep) {
    '.' : thousands_sep, s = n < 0 ? '-' : '';
   var i = parseInt((n = Math.abs(+n || 0).toFixed(c)), 10) + '';
   var j = (i.length > 3) ? i.length % 3 : 0;
-  return s + (j ? i.substr(0, j) + t : '') +
-    i.substr(j).replace(/(\d{3})(?=\d)/g, '$1' + t) +
+  return s + (j ? i.slice(0, j) + t : '') +
+    i.slice(j).replace(/(\d{3})(?=\d)/g, '$1' + t) +
     (c ? d + Math.abs(n - i).toFixed(c).slice(2) : '');
 };
 
@@ -2504,7 +2504,7 @@ util.bytesToIPv6 = function(bytes) {
     var hex = util.bytesToHex(bytes[i] + bytes[i + 1]);
     // canonicalize zero representation
     while(hex[0] === '0' && hex !== '0') {
-      hex = hex.substr(1);
+      hex = hex.slice(1);
     }
     if(hex === '0') {
       var last = zeroGroups[zeroGroups.length - 1];

--- a/tests/benchmarks/so-44303784.js
+++ b/tests/benchmarks/so-44303784.js
@@ -45,7 +45,7 @@ function test_forge_chunk(bytes, chunkSize) {
   let plain = '';
   do {
     plain += decipher.output.getBytes();
-    const buf = forge.util.createBuffer(bytes.substr(index, chunkSize));
+    const buf = forge.util.createBuffer(bytes.slice(index, index + chunkSize));
     decipher.update(buf);
     index += chunkSize;
   } while(index < length);
@@ -131,7 +131,7 @@ function data_chunk(megs, chunkSize) {
   let encrypted = '';
   do {
     encrypted += cipher.output.getBytes();
-    const buf = forge.util.createBuffer(plain.substr(index, chunkSize));
+    const buf = forge.util.createBuffer(plain.slice(index, index + chunkSize));
     cipher.update(buf);
     index += chunkSize;
   } while(index < length);

--- a/tests/websockets/server-webid.js
+++ b/tests/websockets/server-webid.js
@@ -36,7 +36,7 @@ var normalizeNs = function(input, ns) {
       // update namespace map
       for(var key in input['@']) {
         if(key.indexOf('xmlns:') === 0) {
-          ns[key.substr(6)] = input['@'][key];
+          ns[key.slice(6)] = input['@'][key];
         }
       }
     }
@@ -47,9 +47,9 @@ var normalizeNs = function(input, ns) {
         var value = input[key];
         var colon = key.indexOf(':');
         if(colon !== -1) {
-          var prefix = key.substr(0, colon);
+          var prefix = key.slice(0, colon);
           if(prefix in ns) {
-            key = ns[prefix] + key.substr(colon + 1);
+            key = ns[prefix] + key.slice(colon + 1);
           }
         }
         rval[key] = normalizeNs(value, ns);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.