### PR TITLE
Allow DigestInfo.DigestAlgorith.parameters to be optional

### DIFF
--- a/lib/rsa.js
+++ b/lib/rsa.js
@@ -286,6 +286,7 @@ var digestInfoValidator = {
       name: 'DigestInfo.DigestAlgorithm.parameters',
       tagClass: asn1.Class.UNIVERSAL,
       type: asn1.Type.NULL,
+      optional: true,
       constructed: false
     }]
   }, {


### PR DESCRIPTION
Since v2.3.0 PKCS#1 signatures that don't include the `DigestAlgorithm.parameters` data do not parse successfully:

```
 errors: [
    '[DigestInfo.DigestAlgorithm] Tag class "0", type "16" expected value length "2", got "1"',
    '[DigestInfo] Tag class "0", type "16" expected value length "2", got "2"'
  ]
```

RFC3447 dictated that the `parameters` in the `DigestAlgorithm` were optional, however this was updated in RFC8017 to now need to be explicitly specified (even if `NULL`).

Prior to v2.3.0 of `forge` the PKCS#1 verify logic was permissive to the legacy format where the `parameters` were omitted (which was part of why I've been using it over Node's built in `verify`).

This change allows the parameters to, once again, be optional.