### PR TITLE
Allow DigestInfo.DigestAlgorith.parameters to be optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Forge ChangeLog
 ===============
 
+## 1.3.1 - 2022-03-xx
+
+### Fixes
+- RFC 3447 and RFC 8017 allow for optional `DigestAlgorithm` `NULL` parameters
+  for `sha*` algorithms and require `NULL` paramters for `md2` and `md5`
+  algorithms.
+
 ## 1.3.0 - 2022-03-17
 
 ### Security

--- a/lib/rsa.js
+++ b/lib/rsa.js
@@ -286,6 +286,7 @@ var digestInfoValidator = {
       name: 'DigestInfo.DigestAlgorithm.parameters',
       tagClass: asn1.Class.UNIVERSAL,
       type: asn1.Type.NULL,
+      optional: true,
       constructed: false
     }]
   }, {

--- a/lib/rsa.js
+++ b/lib/rsa.js
@@ -286,6 +286,8 @@ var digestInfoValidator = {
       name: 'DigestInfo.DigestAlgorithm.parameters',
       tagClass: asn1.Class.UNIVERSAL,
       type: asn1.Type.NULL,
+      // captured only to check existence for md2 and md5
+      capture: 'parameters',
       optional: true,
       constructed: false
     }]
@@ -1186,6 +1188,16 @@ pki.setRsaPublicKey = pki.rsa.setPublicKey = function(n, e) {
               'Unknown RSASSA-PKCS1-v1_5 DigestAlgorithm identifier.');
             error.oid = oid;
             throw error;
+          }
+
+          // special check for md2 and md5 that NULL parameters exist
+          if(oid === forge.oids.md2 || oid === forge.oids.md5) {
+            if(!('parameters' in capture)) {
+              throw new Error(
+                'ASN.1 object does not contain a valid RSASSA-PKCS1-v1_5 ' +
+                'DigestInfo value. ' +
+                'Missing algorithm identifer NULL parameters.');
+            }
           }
 
           // compare the given digest to the decrypted one

--- a/tests/unit/rsa.js
+++ b/tests/unit/rsa.js
@@ -845,6 +845,15 @@ var UTIL = require('../../lib/util');
         /^Error: ASN.1 object does not contain a valid RSASSA-PKCS1-v1_5 DigestInfo value.$/);
       }
 
+      function _checkGoodDigestInfo(publicKey, S, skipTailingGarbage) {
+        var md = MD.sha256.create();
+        md.update(m);
+
+        ASSERT.ok(publicKey.verify(md.digest().getBytes(), S, undefined, {
+          _parseAllDigestBytes: !skipTailingGarbage
+        }));
+      }
+
       it('should check DigestInfo structure', function() {
         var publicKey = RSA.setPublicKey(N, e);
         // 0xff bytes stolen from padding
@@ -904,7 +913,7 @@ var UTIL = require('../../lib/util');
           '0bc1dd3f020cb1091af6b476416da3024ea046b09fbbbc4d2355da9a2bc6ddb9');
 
         _checkBadTailingGarbage(publicKey, S);
-        _checkBadDigestInfo(publicKey, S, true);
+        _checkGoodDigestInfo(publicKey, S, true);
       });
 
       it('should check tailing garbage and DigestInfo [2]', function() {


### PR DESCRIPTION
- Includes change from https://github.com/digitalbazaar/forge/pull/965.
- Fixes test.
- Handles md2/md5 cases (untested, making a test is difficult).
- Thanks to @dhensby!