### PR TITLE
throw exception instead of returning false, if gcm tag validation evaluates to invalid.

### DIFF
--- a/lib/cipherModes.js
+++ b/lib/cipherModes.js
@@ -731,6 +731,8 @@ modes.gcm.prototype.decrypt = function(input, output, finish) {
   }
 };
 
+var unauthenticException = new Error('Error: MAC Mispatch. Content and/or MAC has been tempared with');
+
 modes.gcm.prototype.afterFinish = function(output, options) {
   var rval = true;
 
@@ -760,7 +762,7 @@ modes.gcm.prototype.afterFinish = function(output, options) {
 
   // check authentication tag
   if(options.decrypt && this.tag.bytes() !== this._tag) {
-    rval = false;
+    throw unauthenticException;
   }
 
   return rval;


### PR DESCRIPTION
BREAKING CHANGE!
Major update.

If aes gcm tag validation evaluates to invalid,
an error / exception should be thrown,
following the gcm specification:
https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf

Otherwise the user of this library has to check the validation which could be forgotten.

Libraries always should do all checks they can do,
so library using developers can just use it.