### PR TITLE
Test on Node 16.x and 18.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x, 14.x]
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
I'd like to have a look at the failed job on CI, since the one from https://github.com/digitalbazaar/forge/pull/976 expired.