### PR TITLE
fix(pkcs12): support different MAC Algorithms for PKCS12 generation

### DIFF
--- a/lib/pkcs12.js
+++ b/lib/pkcs12.js
@@ -268,6 +268,14 @@ var certBagValidator = {
   }]
 };
 
+var algoToOidMap = {
+  sha1: pki.oids.sha1,
+  sha256: pki.oids.sha256,
+  sha384: pki.oids.sha384,
+  sha512: pki.oids.sha512,
+  md5: pki.oids.md5,
+};
+
 /**
  * Search SafeContents structure for bags with matching attributes.
  *
@@ -305,6 +313,27 @@ function _getBagsByAttribute(safeContents, attrName, attrValue, bagType) {
 }
 
 /**
+ * Converts a PKCS#12 PFX in ASN.1 notation and returns the captured data
+ *
+ * If invalid, then it throws error
+ *
+ * @param obj The PKCS#12 PFX in ASN.1 notation.
+ * @returns capture captured data as specified in pfxValidator
+ */
+p12.validatePfx = function(obj) {
+  var capture = {};
+  var errors = [];
+  if(!asn1.validate(obj, pfxValidator, capture, errors)) {
+    var error = new Error('Cannot read PKCS#12 PFX. ' +
+      'ASN.1 object is not an PKCS#12 PFX.');
+    error.errors = errors;
+    throw error;
+  }
+
+  return capture;
+};
+
+/**
  * Converts a PKCS#12 PFX in ASN.1 notation into a PFX object.
  *
  * @param obj The PKCS#12 PFX in ASN.1 notation.
@@ -323,14 +352,7 @@ p12.pkcs12FromAsn1 = function(obj, strict, password) {
   }
 
   // validate PFX and capture data
-  var capture = {};
-  var errors = [];
-  if(!asn1.validate(obj, pfxValidator, capture, errors)) {
-    var error = new Error('Cannot read PKCS#12 PFX. ' +
-      'ASN.1 object is not an PKCS#12 PFX.');
-    error.errors = error;
-    throw error;
-  }
+  var capture = p12.validatePfx(obj);
 
   var pfx = {
     version: capture.version.charCodeAt(0),
@@ -433,32 +455,26 @@ p12.pkcs12FromAsn1 = function(obj, strict, password) {
   // check for MAC
   if(capture.mac) {
     var md = null;
-    var macKeyBytes = 0;
-    var macAlgorithm = asn1.derToOid(capture.macAlgorithm);
-    switch(macAlgorithm) {
-    case pki.oids.sha1:
-      md = forge.md.sha1.create();
-      macKeyBytes = 20;
-      break;
-    case pki.oids.sha256:
-      md = forge.md.sha256.create();
-      macKeyBytes = 32;
-      break;
-    case pki.oids.sha384:
-      md = forge.md.sha384.create();
-      macKeyBytes = 48;
-      break;
-    case pki.oids.sha512:
-      md = forge.md.sha512.create();
-      macKeyBytes = 64;
-      break;
-    case pki.oids.md5:
-      md = forge.md.md5.create();
-      macKeyBytes = 16;
-      break;
+    var macAlgorithmOid = asn1.derToOid(capture.macAlgorithm);
+    switch(macAlgorithmOid) {
+      case pki.oids.sha1:
+        md = forge.md.sha1.create();
+        break;
+      case pki.oids.sha256:
+        md = forge.md.sha256.create();
+        break;
+      case pki.oids.sha384:
+        md = forge.md.sha384.create();
+        break;
+      case pki.oids.sha512:
+        md = forge.md.sha512.create();
+        break;
+      case pki.oids.md5:
+        md = forge.md.md5.create();
+        break;
     }
     if(md === null) {
-      throw new Error('PKCS#12 uses unsupported MAC algorithm: ' + macAlgorithm);
+      throw new Error('PKCS#12 uses unsupported MAC algorithm: ' + macAlgorithmOid);
     }
 
     // verify MAC (iterations default to 1)
@@ -466,7 +482,7 @@ p12.pkcs12FromAsn1 = function(obj, strict, password) {
     var macIterations = (('macIterations' in capture) ?
       parseInt(forge.util.bytesToHex(capture.macIterations), 16) : 1);
     var macKey = p12.generateKey(
-      password, macSalt, 3, macIterations, macKeyBytes, md);
+      password, macSalt, 3, macIterations, md.digestLength, md);
     var mac = forge.hmac.create();
     mac.start(md, macKey);
     mac.update(data.value);
@@ -799,6 +815,15 @@ p12.toPkcs12Asn1 = function(key, cert, password, options) {
   options.saltSize = options.saltSize || 8;
   options.count = options.count || 2048;
   options.algorithm = options.algorithm || options.encAlgorithm || 'aes128';
+
+  // process macAlgorithm option
+  options.macAlgorithm = options.macAlgorithm || 'sha1';
+  var macAlgorithm = forge.md.algorithms[options.macAlgorithm] || '';
+  var macAlgoirthmOid = algoToOidMap[options.macAlgorithm] || '';
+  if(!macAlgorithm || !macAlgoirthmOid) {
+    throw new Error('PKCS#12 unsupported MAC algorithm: ' + options.macAlgorithm);
+  }
+
   if(!('useMac' in options)) {
     options.useMac = true;
   }
@@ -820,9 +845,10 @@ p12.toPkcs12Asn1 = function(key, cert, password, options) {
       if(typeof pairedCert === 'string') {
         pairedCert = pki.certificateFromPem(pairedCert);
       }
-      var sha1 = forge.md.sha1.create();
-      sha1.update(asn1.toDer(pki.certificateToAsn1(pairedCert)).getBytes());
-      localKeyId = sha1.digest().getBytes();
+
+      var md = macAlgorithm.create();
+      md.update(asn1.toDer(pki.certificateToAsn1(pairedCert)).getBytes());
+      localKeyId = md.digest().getBytes();
     } else {
       // FIXME: consider using SHA-1 of public key (which can be generated
       // from private key components), see: cert.generateSubjectKeyIdentifier
@@ -1000,14 +1026,14 @@ p12.toPkcs12Asn1 = function(key, cert, password, options) {
   var macData;
   if(options.useMac) {
     // MacData
-    var sha1 = forge.md.sha1.create();
+    var md = macAlgorithm.create();
     var macSalt = new forge.util.ByteBuffer(
       forge.random.getBytes(options.saltSize));
     var count = options.count;
     // 160-bit key
-    var key = p12.generateKey(password, macSalt, 3, count, 20);
+    var key = p12.generateKey(password, macSalt, 3, count, md.digestLength, md);
     var mac = forge.hmac.create();
-    mac.start(sha1, key);
+    mac.start(md, key);
     mac.update(asn1.toDer(safe).getBytes());
     var macValue = mac.getMac();
     macData = asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
@@ -1017,7 +1043,7 @@ p12.toPkcs12Asn1 = function(key, cert, password, options) {
         asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
           // algorithm = SHA-1
           asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OID, false,
-            asn1.oidToDer(pki.oids.sha1).getBytes()),
+            asn1.oidToDer(macAlgoirthmOid).getBytes()),
           // parameters = Null
           asn1.create(asn1.Class.UNIVERSAL, asn1.Type.NULL, false, '')
         ]),


### PR DESCRIPTION
This PR includes the following
- Support different MAC Algoirthms for PKCS12 (PFX) generation
- Adds unit test for `sha1`, `sha256`, `sha384`, `sha512` and `md5`

Closes: #1061 