### PR TITLE
pkcs7 PublicKey + RSASSA-PSS support

### DIFF
--- a/lib/pkcs7.js
+++ b/lib/pkcs7.js
@@ -247,6 +247,8 @@ p7.createSignedData = function() {
      *            to also sign along with the content.
      */
     addSigner: function(signer) {
+      var version = (signer.subjectKeyIdentifier) ? 3 : 1;
+      var subjectKeyIdentifier = signer.subjectKeyIdentifier;
       var issuer = signer.issuer;
       var serialNumber = signer.serialNumber;
       if(signer.certificate) {
@@ -280,6 +282,8 @@ p7.createSignedData = function() {
           'Could not add PKCS#7 signer; unknown message digest algorithm: ' +
           digestAlgorithm);
       }
+
+      let signatureAlgorithm = (signer.signatureAlgorithm) ? signer.signatureAlgorithm : forge.pki.oids.rsaEncryption;
 
       // if authenticatedAttributes is present, then the attributes
       // must contain at least PKCS #9 content-type and message-digest
@@ -315,11 +319,12 @@ p7.createSignedData = function() {
 
       msg.signers.push({
         key: key,
-        version: 1,
+        version: version,
         issuer: issuer,
         serialNumber: serialNumber,
+        subjectKeyIdentifier: subjectKeyIdentifier,
         digestAlgorithm: digestAlgorithm,
-        signatureAlgorithm: forge.pki.oids.rsaEncryption,
+        signatureAlgorithm: signatureAlgorithm,
         signature: null,
         authenticatedAttributes: authenticatedAttributes,
         unauthenticatedAttributes: []
@@ -374,7 +379,7 @@ p7.createSignedData = function() {
       var mds = addDigestAlgorithmIds();
 
       // generate signerInfos
-      addSignerInfos(mds);
+      addSignerInfos(mds, options);
     },
 
     verify: function() {
@@ -443,7 +448,7 @@ p7.createSignedData = function() {
     return mds;
   }
 
-  function addSignerInfos(mds) {
+  function addSignerInfos(mds, options) {
     var content;
 
     if (msg.detachedContent) {
@@ -531,7 +536,7 @@ p7.createSignedData = function() {
       }
 
       // sign digest
-      signer.signature = signer.key.sign(signer.md, 'RSASSA-PKCS1-V1_5');
+      signer.signature = signer.key.sign(signer.md, (options.scheme) ? options.scheme : 'RSASSA-PKCS1-V1_5');
     }
 
     // add signer info
@@ -712,6 +717,27 @@ p7.createEnvelopedData = function() {
     },
 
     /**
+     * Add (another) entity to list of recipients.
+     *
+     * @param publicKey
+     * @param subjectKeyIdentifier
+     */
+    addRecipientPublicKey: function(publicKey, subjectKeyIdentifier) {
+      let key = (typeof publicKey === 'string') ? forge.pki.publicKeyFromPem(publicKey) : publicKey;
+      msg.recipients.push({
+        version: 2,
+        subjectKeyIdentifier: subjectKeyIdentifier,
+        encryptedContent: {
+          // We simply assume rsaEncryption here, since forge.pki only
+          // supports RSA so far.  If the PKI module supports other
+          // ciphers one day, we need to modify this one as well.
+          algorithm: forge.pki.oids.rsaEncryption,
+          key: key
+        }
+      });
+    },
+
+    /**
      * Encrypt enveloped content.
      *
      * This function supports two optional arguments, cipher and key, which
@@ -843,6 +869,23 @@ function _recipientFromAsn1(obj) {
   };
 }
 
+function _createAsn1RecipientIdentifier(obj) {
+  if (obj.version === 2) {
+    // subjectKeyIdentifier
+    return asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OCTETSTRING, false,
+      obj.subjectKeyIdentifier);
+  } else {
+    // issuerAndSerialNumber
+    return asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+      // name
+      forge.pki.distinguishedNameToAsn1({attributes: obj.issuer}),
+      // serial
+      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,
+        forge.util.hexToBytes(obj.serialNumber))
+    ]);
+  }
+}
+
 /**
  * Converts a single recipient object to an ASN.1 object.
  *
@@ -855,14 +898,7 @@ function _recipientToAsn1(obj) {
     // Version
     asn1.create(asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,
       asn1.integerToDer(obj.version).getBytes()),
-    // IssuerAndSerialNumber
-    asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
-      // Name
-      forge.pki.distinguishedNameToAsn1({attributes: obj.issuer}),
-      // Serial
-      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,
-        forge.util.hexToBytes(obj.serialNumber))
-    ]),
+    _createAsn1RecipientIdentifier(obj),
     // KeyEncryptionAlgorithmIdentifier
     asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
       // Algorithm
@@ -943,6 +979,51 @@ function _signerFromAsn1(obj) {
   return rval;
 }
 
+function _createAsn1SignerIdentifier(obj) {
+  if (obj.version === 3) {
+    // subjectKeyIdentifier
+    return asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OCTETSTRING, false,
+      obj.subjectKeyIdentifier);
+  } else {
+    // issuerAndSerialNumber
+    return asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+      // name
+      forge.pki.distinguishedNameToAsn1({attributes: obj.issuer}),
+      // serial
+      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,
+        forge.util.hexToBytes(obj.serialNumber))
+    ]);
+  }
+}
+
+function _createDigestEncryptionAlgorithmParameters(obj) {
+  if (obj.signatureAlgorithm === forge.pki.oids['RSASSA-PSS']) {
+    // Parameters: hashAlgorithm, maskGenAlgorithm (MGF1 + hash algorithm), saltLength (expects length of hash as recommended)
+    return asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+      asn1.create(asn1.Class.CONTEXT_SPECIFIC, 0, true, [
+        asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+          asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OID, false, asn1.oidToDer(obj.digestAlgorithm).getBytes()),
+          asn1.create(asn1.Class.UNIVERSAL, asn1.Type.NULL, false, ''),
+        ])
+      ]),
+      asn1.create(asn1.Class.CONTEXT_SPECIFIC, 1, true, [
+        asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+          asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OID, false, asn1.oidToDer(forge.oids.mgf1).getBytes()),
+          asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+            asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OID, false, asn1.oidToDer(obj.digestAlgorithm).getBytes()),
+            asn1.create(asn1.Class.UNIVERSAL, asn1.Type.NULL, false, '')
+          ])
+        ]),
+      ]),
+      asn1.create(asn1.Class.CONTEXT_SPECIFIC, 2, true, [
+        asn1.create(asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false, asn1.integerToDer(obj.signature.length / 8).getBytes())
+      ]),
+    ]);
+  }
+  // parameters (null)
+  return asn1.create(asn1.Class.UNIVERSAL, asn1.Type.NULL, false, '');
+}
+
 /**
  * Converts a single signerInfo object to an ASN.1 object.
  *
@@ -956,14 +1037,7 @@ function _signerToAsn1(obj) {
     // version
     asn1.create(asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,
       asn1.integerToDer(obj.version).getBytes()),
-    // issuerAndSerialNumber
-    asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
-      // name
-      forge.pki.distinguishedNameToAsn1({attributes: obj.issuer}),
-      // serial
-      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,
-        forge.util.hexToBytes(obj.serialNumber))
-    ]),
+    _createAsn1SignerIdentifier(obj),
     // digestAlgorithm
     asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
       // algorithm
@@ -985,8 +1059,7 @@ function _signerToAsn1(obj) {
     // algorithm
     asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OID, false,
       asn1.oidToDer(obj.signatureAlgorithm).getBytes()),
-    // parameters (null)
-    asn1.create(asn1.Class.UNIVERSAL, asn1.Type.NULL, false, '')
+      _createDigestEncryptionAlgorithmParameters(obj)
   ]));
 
   // encryptedDigest

--- a/lib/pki.js
+++ b/lib/pki.js
@@ -100,3 +100,26 @@ pki.privateKeyInfoToPem = function(pki, maxline) {
   };
   return forge.pem.encode(msg, {maxline: maxline});
 };
+
+/**
+ * Converts an RSA private key from PEM format.
+ *
+ * @param pem the PEM-formatted private key.
+ *
+ * @return the private key.
+ */
+pki.publicKeyFromPem = function(pem) {
+  var msg = forge.pem.decode(pem)[0];
+
+  if(msg.type !== 'PUBLIC KEY' && msg.type !== 'RSA PUBLIC KEY') {
+    var error = new Error('Could not convert public key from PEM; PEM ' +
+      'header type is not "PUBLIC KEY" or "RSA PUBLIC KEY".');
+    error.headerType = msg.type;
+    throw error;
+  }
+
+  // convert DER to ASN.1 object
+  var obj = asn1.fromDer(msg.body);
+
+  return pki.publicKeyFromAsn1(obj);
+};


### PR DESCRIPTION
Supports defining following elements in pkcs signing and encryption:
* SubjectKeyIdentifier as SignerIdentifier (alternative choice for IssuerAndSerialNumber)
* SubjectKeyIdentifier as RecipientIdentifier (alternative choice for IssuerAndSerialNumber)
* support for RSASSA-PSS as scheme (defaults to RSASSA-PKCS1-V1_5, which was fixed value)

Context:
* By supporting subjectKeyIdentifier as signer- and recipient identifiers, it is possible to work with an online registry of public keys (no need for certificates) for both signer and verifier.
* RSASSA-PSS is more secure then RSASSA-PKCS1 and requires a little addition to the code since it is allready supported for signing other messages then pkcs7.