### PR TITLE
Add a fallback global scope for runtime likes wechat mini program

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -120,7 +120,11 @@ util.globalScope = (function() {
     return global;
   }
 
-  return typeof self === 'undefined' ? window : self;
+  return typeof self !== "undefined"
+    ? self
+    : typeof window !== "undefined"
+    ? window
+    : new Function("return this")();
 })();
 
 // define isArray


### PR DESCRIPTION
WeChat Mini Program is a popular application form in China, similar to Progressive Web Apps but with a specific runtime and system interface provided by the application platform (wechat indeeded). Its runtime is similar to a browser or React Native but lacks global objects like document, window, self. As a result, using node-forge in WeChat Mini Program would cause crashes due to the inability to find the global space, leading to issues like #1028 and #1027.

A few years ago, I made some minor efforts to support running such JavaScript modules in those environments, including [applying a runtime patch](https://github.com/tinajs/mina-webpack/blob/master/packages/mina-runtime-webpack-plugin/polyfill.js) for JS dependencies. However, this implementation heavily depends on webpack.

Especially with the popularity of various mini programs and cross-platform frameworks today, I believe that adding a fallback logic directly in node-forge can prevent crashes in such scenarios.

Hope this will be helpful for other mini program or hybrid developers as well. 😘