### PR TITLE
fix: jsbn use util.isNodejs to determine node runtime

### DIFF
--- a/lib/jsbn.js
+++ b/lib/jsbn.js
@@ -117,7 +117,7 @@ function am3(i,x,w,j,c,n) {
 }
 
 // node.js (no browser)
-if(typeof(navigator) === 'undefined')
+if(forge.util.isNodejs)
 {
    BigInteger.prototype.am = am3;
    dbits = 28;


### PR DESCRIPTION
fixes #1081 

A simple fix to avoid using the `navigator` global for determining if we are running node, instead use the forge `util.isNodejs` value.

TBH - I have no idea if the assumptions around performance in different browsers still holds since 2005 (almost 20 years ago) - but this at least keeps the node performance where it was.