### PR TITLE
feat: Enhance URL validation in console logger

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -298,7 +298,7 @@ if(typeof(console) !== 'undefined' && 'log' in console) {
  * that could otherwise be limited by a user config.
  */
 if(sConsoleLogger !== null &&
-  typeof window !== 'undefined' && window.location
+  typeof window !== 'undefined' && window.location && typeof URL !== 'undefined'
 ) {
   var query = new URL(window.location.href).searchParams;
   if(query.has('console.level')) {


### PR DESCRIPTION
## Changes
- Add URL API availability check before using URL constructor
- Include `typeof URL !== 'undefined'` condition to prevent errors in environments without URL API support

## Why
- Some older browsers or special runtime environments may not support the URL API
- This check prevents ReferenceError from being thrown in such environments

## Impact
- Improves code robustness and compatibility
- No functional changes in modern browsers that support URL API

Fixes potential ReferenceError when URL API is not available