### PR TITLE
Fix jsbn browser check

### DIFF
--- a/lib/jsbn.js
+++ b/lib/jsbn.js
@@ -116,8 +116,8 @@ function am3(i,x,w,j,c,n) {
   return c;
 }
 
-// node.js (no browser)
-if(typeof(navigator) === 'undefined')
+// node.js/bun/deno (no browser), latest versions have 'navigator' defined, but 'navigator.appName' is still undefined
+if(typeof(navigator) === 'undefined' || typeof(navigator.appName) === 'undefined')
 {
    BigInteger.prototype.am = am3;
    dbits = 28;


### PR DESCRIPTION
fixes https://github.com/digitalbazaar/forge/issues/1081

Previous versions of NodeJS/Bun/Deno didn't have 'navigator' defined, while latest one do have it, which forces am2 algorithm with 26 dbits, which is awfully slow (~20x), at least in NodeJS v22 (compared to am3 with 28 dbits)