### PR TITLE
Fix Typo (tmp.length() -> tmp.length)

### DIFF
--- a/lib/aes.js
+++ b/lib/aes.js
@@ -200,7 +200,7 @@ forge.aes.Algorithm.prototype.initialize = function(options) {
     key = [];
 
     // key lengths of 16, 24, 32 bytes allowed
-    var len = tmp.length();
+    var len = tmp.length;
     if(len === 16 || len === 24 || len === 32) {
       len = len >>> 2;
       for(var i = 0; i < len; ++i) {


### PR DESCRIPTION
So I think I encountered a typo in the aes.js lib file. On line 203, the length of `tmp` is found using `tmp.length()`. But,
    a) this results in a type error complaining that `tmp.length() is not a function` (See [Issue #552 ](https://github.com/digitalbazaar/forge/issues/552) 
    b) it is done the correct way (at least, as far as I can tell) not 10 lines earlier. I have provided an excerpt from `aes.js`:
```
183 |  if(typeof key === 'string' &&
184 |    (key.length === 16 || key.length === 24 || key.length === 32)) {
185 |    // convert key string into byte buffer
186 |    key = forge.util.createBuffer(key);
187 |  } else if(forge.util.isArray(key) &&
188 |    (key.length === 16 || key.length === 24 || key.length === 32)) {
189 |    // convert key integer array into byte buffer
190 |    tmp = key;
191 |    key = forge.util.createBuffer();
192 |    for(var i = 0; i < tmp.length; ++i) {
193 |      key.putByte(tmp[i]);
194 |    }
195 |  }
196 |
197 |  // convert key byte buffer into 32-bit integer array
198 |  if(!forge.util.isArray(key)) {
199 |    tmp = key;
200 |    key = [];
201 |
202 |    // key lengths of 16, 24, 32 bytes allowed
203 |    var len = tmp.length();
204 |    if(len === 16 || len === 24 || len === 32) {
205 |      len = len >>> 2;
206 |      for(var i = 0; i < len; ++i) {
207 |        key.push(tmp.getInt32());
208 |      }
209 |    }
210 |  }
```

So this pull request addresses that by chaning line 203 from `var len = tmp.length();` to `var len = tmp.length;`
Hope i'm not wrong about it, but it seems like a no brainer.