### PR TITLE
fix: enforce pathLenConstraint regardless of keyUsage extension

### DIFF
--- a/lib/x509.js
+++ b/lib/x509.js
@@ -3186,10 +3186,10 @@ pki.verifyCertificateChain = function(caStore, chain, options) {
           error: pki.certificateError.bad_certificate
         };
       }
-      // if error is not null and keyUsage is available, then we know it
-      // has keyCertSign and there is a basic constraints extension too,
-      // which means we can check pathLenConstraint (if it exists)
-      if(error === null && keyUsageExt !== null &&
+      // if error is not null and basic constraints extension exists,
+      // check pathLenConstraint (if it exists); this must be enforced
+      // regardless of whether keyUsage extension is present
+      if(error === null && bcExt !== null &&
         'pathLenConstraint' in bcExt) {
         // pathLen is the maximum # of intermediate CA certs that can be
         // found between the current certificate and the end-entity (depth 0)


### PR DESCRIPTION
## Summary

The `pathLenConstraint` check in `_verifyCertificateChain` (lib/x509.js) was gated on `keyUsageExt !== null`, allowing a CA certificate **without** the keyUsage extension to bypass path length constraints entirely. OpenSSL correctly rejects the same chain.

This changes the condition from `keyUsageExt !== null` to `bcExt !== null`, ensuring `pathLenConstraint` from basicConstraints is always enforced on CA certificates.

## Security Advisory

Ref: [GHSA-h8mc-2r26-8398](https://github.com/digitalbazaar/forge/security/advisories/GHSA-h8mc-2r26-8398)

## Details

**Before (vulnerable):**
```js
if(error === null && keyUsageExt !== null &&
  'pathLenConstraint' in bcExt) {
```

A CA cert that omits keyUsage but sets `basicConstraints.pathLenConstraint = 0` can still issue intermediate CA certs, violating the path length limit.

**After (fixed):**
```js
if(error === null && bcExt !== null &&
  'pathLenConstraint' in bcExt) {
```

The pathLenConstraint is now checked whenever basicConstraints is present, regardless of whether keyUsage exists.