### PR TITLE
fix: enforce pathLenConstraint regardless of keyUsage extension

### DIFF
--- a/lib/x509.js
+++ b/lib/x509.js
@@ -3186,10 +3186,9 @@ pki.verifyCertificateChain = function(caStore, chain, options) {
           error: pki.certificateError.bad_certificate
         };
       }
-      // if error is not null and keyUsage is available, then we know it
-      // has keyCertSign and there is a basic constraints extension too,
-      // which means we can check pathLenConstraint (if it exists)
-      if(error === null && keyUsageExt !== null &&
+      // check pathLenConstraint (if it exists) regardless of whether
+      // keyUsage extension is present
+      if(error === null && bcExt !== null &&
         'pathLenConstraint' in bcExt) {
         // pathLen is the maximum # of intermediate CA certs that can be
         // found between the current certificate and the end-entity (depth 0)


### PR DESCRIPTION
## Summary

Fixes GHSA-h8mc-2r26-8398. This replaces #1141.

The `pathLenConstraint` check in `verifyCertificateChain` was gated on the `keyUsage` extension being present (`keyUsageExt !== null`). When a CA certificate omitted the `keyUsage` extension but included `basicConstraints` with a `pathLenConstraint`, the constraint was silently skipped — allowing certificate chains that exceeded the maximum permitted intermediate CA depth.

## Changes

In `lib/x509.js`, the condition guarding the `pathLenConstraint` enforcement now checks for `bcExt !== null` instead of `keyUsageExt !== null`, so the constraint is enforced whenever `basicConstraints` is present, regardless of whether `keyUsage` is also present.