### PR TITLE
Fix encoding/decoding of multi-byte first OID subidentifier

### DIFF
--- a/lib/asn1.js
+++ b/lib/asn1.js
@@ -778,17 +778,18 @@ asn1.oidToDer = function(oid) {
   var values = oid.split('.');
   var bytes = forge.util.createBuffer();
 
-  // first byte is 40 * value1 + value2
-  bytes.putByte(40 * parseInt(values[0], 10) + parseInt(values[1], 10));
-  // other bytes are each value in base 128 with 8th bit set except for
-  // the last byte for each value
+  // the first subidentifier is 40 * value1 + value2; the remaining
+  // subidentifiers are each a single value. every subidentifier is encoded in
+  // base 128 with the 8th bit set on every byte except its last.
   var last, valueBytes, value, b;
-  for(var i = 2; i < values.length; ++i) {
+  for(var i = 1; i < values.length; ++i) {
     // produce value bytes in reverse because we don't know how many
     // bytes it will take to store the value
     last = true;
     valueBytes = [];
-    value = parseInt(values[i], 10);
+    value = (i === 1) ?
+      40 * parseInt(values[0], 10) + parseInt(values[1], 10) :
+      parseInt(values[i], 10);
     // TODO: Change bitwise logic to allow larger values.
     if(value > 0xffffffff) {
       throw new Error('OID value too large; max is 32-bits.');
@@ -830,13 +831,12 @@ asn1.derToOid = function(bytes) {
     bytes = forge.util.createBuffer(bytes);
   }
 
-  // first byte is 40 * value1 + value2
-  var b = bytes.getByte();
-  oid = Math.floor(b / 40) + '.' + (b % 40);
-
-  // other bytes are each value in base 128 with 8th bit set except for
-  // the last byte for each value
+  // each subidentifier is encoded in base 128 with the 8th bit set on every
+  // byte except its last; the first subidentifier encodes the first two arcs
+  // as 40 * value1 + value2.
+  var b;
   var value = 0;
+  var first = true;
   while(bytes.length() > 0) {
     // error if 7b shift would exceed Number.MAX_SAFE_INTEGER
     // (Number.MAX_SAFE_INTEGER / 128)
@@ -850,7 +850,16 @@ asn1.derToOid = function(bytes) {
       value += b & 0x7F;
     } else {
       // last byte
-      oid += '.' + (value + b);
+      value += b;
+      if(first) {
+        // split the first subidentifier into the first two arcs
+        oid = (value < 80) ?
+          Math.floor(value / 40) + '.' + (value % 40) :
+          '2.' + (value - 80);
+        first = false;
+      } else {
+        oid += '.' + value;
+      }
       value = 0;
     }
   }

--- a/tests/unit/asn1.js
+++ b/tests/unit/asn1.js
@@ -54,6 +54,18 @@ var UTIL = require('../../lib/util');
       );
     });
 
+    it('should convert an OID with a multi-byte first subidentifier to DER', function() {
+      // X.690 8.19: the first subidentifier (40 * arc1 + arc2) can exceed one
+      // byte when arc1 is 2, so it must be encoded in base 128
+      ASSERT.equal(ASN1.oidToDer('2.999.3').toHex(), '883703');
+      ASSERT.equal(ASN1.oidToDer('2.100').toHex(), '8134');
+    });
+
+    it('should convert an OID with a multi-byte first subidentifier from DER', function() {
+      ASSERT.equal(ASN1.derToOid(UTIL.hexToBytes('883703')), '2.999.3');
+      ASSERT.equal(ASN1.derToOid(UTIL.hexToBytes('8134')), '2.100');
+    });
+
     it('should convert INTEGER 0 to DER', function() {
       ASSERT.equal(ASN1.integerToDer(0).toHex(), '00');
     });


### PR DESCRIPTION
### Problem

`asn1.oidToDer` / `asn1.derToOid` mis-handle the first OID subidentifier when it spans more than one byte. The first subidentifier encodes the first two arcs as `40 * arc1 + arc2`; per X.690 §8.19 it is a base-128 multi-byte value like every other subidentifier, so for `arc1 === 2` (where `arc2` is unbounded) it routinely exceeds one byte. Both directions corrupt such OIDs:

```js
const forge = require('node-forge');
forge.asn1.oidToDer('2.999.3').toHex();                  // '43703'     wrong (X.690: '883703')
forge.asn1.derToOid(forge.util.hexToBytes('883703'));   // '3.16.55.3' wrong (X.690: '2.999.3')
forge.asn1.oidToDer('2.100').toHex();                   // 'b4'        wrong (X.690: '8134')
```

- **Encode** writes `40*arc1 + arc2` with a single `putByte`, truncating values ≥ 256 and never setting the continuation bit (so values in 128–255 produce a byte a decoder reads as "more bytes follow").
- **Decode** reads exactly one byte and splits it, ignoring the continuation bit, so a multi-byte first subidentifier is shredded into bogus arcs (and can emit a structurally impossible root arc of `3`).

This is not limited to the `2.999` example arc: registered arcs that appear in real certificates are affected, e.g. **2.41.x (biometrics, ISO/IEC JTC 1 SC 37), 2.49.x (NATO), 2.51.x (GS1)**. Any DER carrying such an OID is written wrong and read wrong.

### Fix

- `oidToDer`: feed the first subidentifier through the existing base-128 emitter instead of a raw `putByte`.
- `derToOid`: accumulate the first subidentifier across continuation bytes like every other subidentifier, then split it (`value < 80 → ⌊value/40⌋.value%40`, else `2.(value−80)`).

### Verification

- New round-trip tests for a multi-byte first subidentifier (`2.999.3` ↔ `883703`, `2.100` ↔ `8134`); they fail on `main` and pass with the fix.
- Output cross-checked against OpenSSL `asn1parse` and an independent X.690 §8.19 implementation across an OID fuzz (first-arc sweeps + random wide arcs): 0 mismatches, and 0 changes to previously-correct OIDs.
- The existing `asn1`, `oids`, `x509`, `pem` suites pass unchanged.

The pre-existing >32-bit-arc limitation (the `0xffffffff` guard / `TODO`) is unchanged and out of scope.